### PR TITLE
Fix for issue #9

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -439,6 +439,11 @@ function Graph() {
                 Math.min(w / Math.max(xMax - xMin, 1),
                          h / Math.max(yMax - yMin, 1));
 
+    xMax += self.p.maxNodeSize;
+    xMin -= self.p.maxNodeSize;
+    yMax += self.p.maxNodeSize;
+    yMin -= self.p.maxNodeSize;            
+
     // Size homothetic parameters:
     var a, b;
     if (!self.p.maxNodeSize && !self.p.minNodeSize) {
@@ -471,6 +476,17 @@ function Graph() {
       if (!node['fixed']) {
         node['displayX'] = (node['x'] - (xMax + xMin) / 2) * scale + w / 2;
         node['displayY'] = (node['y'] - (yMax + yMin) / 2) * scale + h / 2;
+
+        if(node['displayX'] < self.p.maxNodeSize) {
+          node['displayX'] += self.p.maxNodeSize;
+        } else if(node['displayX'] >= (w - self.p.maxNodeSize)) {
+          node['displayX'] -= self.p.maxNodeSize;
+        }
+        if(node['displayY'] < self.p.maxNodeSize) {
+          node['displayY'] += self.p.maxNodeSize;
+        } else if(node['displayY'] >= (h - self.p.maxNodeSize)) {
+          node['displayY'] -= self.p.maxNodeSize;
+        }
       }
     });
 


### PR DESCRIPTION
I seem to have found a solution to the issue i opened on your repo a couple of days ago :)

By checking `displayX` and `displayY`'s values at the end of the rescaling against `maxNodeSize` i can change them to avoid half node circles falling outside the canvas.

I don't really know if maybe adding a configProperty to enable this behavior may be appropriate, i just left it as it is in the commit as it suited my needs.
