### PR TITLE
Function to parse GEXF separated from the download part.

### DIFF
--- a/plugins/sigma.parseGexf.js
+++ b/plugins/sigma.parseGexf.js
@@ -3,7 +3,6 @@
 sigma.publicPrototype.parseGexf = function(gexfPath) {
   // Load XML file:
   var gexfhttp, gexf;
-  var sigmaInstance = this;
   gexfhttp = window.XMLHttpRequest ?
     new XMLHttpRequest() :
     new ActiveXObject('Microsoft.XMLHTTP');
@@ -13,6 +12,14 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
   gexfhttp.send();
   gexf = gexfhttp.responseXML;
 
+  this.parseGexfDocument(gexf);
+}
+
+// Parse the given GEXF document. Is used by parseGexf, but
+// can also handle GEXF documents that have been created using
+// XSLT.
+sigma.publicPrototype.parseGexfDocument = function(gexf) {
+  var sigmaInstance = this;
   var viz='http://www.gexf.net/1.2draft/viz'; // Vis namespace
   var i, j, k;
 


### PR DESCRIPTION
The parseGexf function insists that the GEXF document comes from the server. In my use-case I already had the data on the client side, ran an XSLT to get a GEXF document, which I then needed to pass to the parser.

I split the code so that it is now possible to do both. You can either download GEXF files as beforehand, or you can just pass an existing document to the new parseGexfDocument function.

Joachim
