### PR TITLE
x and y in hello world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,19 @@ This method will return an object, with its own graph and the different public m
 
 To fill the graph, use :
 
-    sigInst.addNode('hello',{
-      'label': 'Hello'
-    }).addNode('world',{
-      'label': 'World!'
+    sigInst.addNode('hello', {
+      label: 'Hello',
+      x: Math.random(),
+      y: Math.random()
+    }).addNode('world', {
+      label: 'World!',
+      x: Math.random(),
+      y: Math.random()
     }).addEdge('hello','world');
 
 Also, a lot of different parameters are available to customize the way your instance work. For example :
 
-    instance.drawingProperties({
+    sigInst.drawingProperties({
       defaultEdgeType: 'curve'
     }).mouseProperties({
       maxRatio: 32


### PR DESCRIPTION
I'm new to sigma.js and I was following the hello world example, but couldn't figure out why both nodes weren't displaying properly. I didn't realize that x and y would default to the center of the graph, and "world" would overlay on top of the "hello". I just thought adding the x and y parameters to the example would make this potentially clearer to new users, maybe.
