### PR TITLE
Switching from Google Closure to UglifyJS2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/*.js
 doc/
 examples/
 css/
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 CONCAT_PATH=build/sigma.concat.js
 MINIFY_PATH=build/sigma.min.js
 TEMP_PATH=build/tmp.js
-CLOSURE=build/compiler.jar
 BUILD=build
 LICENSE=/* sigmajs.org - an open-source light-weight JavaScript graph drawing library - Version: 0.1 - Author:  Alexis Jacomy - License: MIT */
 
-all: clean concat minify-simple
+all: clean concat minify
 check:
 	gjslint --nojsdoc -r src/ -x "src/sigmaintro.js,src/sigmaoutro.js"
 fix:
@@ -15,9 +14,8 @@ clean:
 concat:
 	[ -d ${BUILD} ] || mkdir ${BUILD}
 	cat ./src/intro.js `find ./src/classes -name "*.js"` ./src/sigmaintro.js `find ./src/core -name "*.js"` `find ./src/public -name "*.js"` ./src/sigmaoutro.js > ${CONCAT_PATH}
-minify-simple: clean concat
-	java -jar ${CLOSURE} --compilation_level SIMPLE_OPTIMIZATIONS --js ${CONCAT_PATH} --js_output_file ${MINIFY_PATH}
-	echo "${LICENSE}" > ${TEMP_PATH} && cat ${MINIFY_PATH} >> ${TEMP_PATH} && mv ${TEMP_PATH} ${MINIFY_PATH}
-minify-advanced: clean concat
-	java -jar ${CLOSURE} --compilation_level ADVANCED_OPTIMIZATIONS --js ${CONCAT_PATH} --js_output_file ${MINIFY_PATH}
+install-build-deps:
+	npm install
+minify: clean concat install-build-deps
+	`npm bin`/uglifyjs2 ${CONCAT_PATH} -c > ${MINIFY_PATH}
 	echo "${LICENSE}" > ${TEMP_PATH} && cat ${MINIFY_PATH} >> ${TEMP_PATH} && mv ${TEMP_PATH} ${MINIFY_PATH}

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Some full examples are available at [sigmajs.org/examples.html](http://sigmajs.o
 ###Build
 To build *sigma.js* :
 
-* Download the [Google Closure Compiler](http://code.google.com/closure/compiler/) and put the .jar file in `/build`
-* Use `make minify-simple` or `make minify-advanced` to minify concatenation result (*Warning*: `make minify-advanced` is pretty agressive on renaming, and this minification has not been tested yet).
-* You can also just use `make concat` to obtain an unminified but working version of *sigma.js*, without the need of the Closure Compiler
+* Install [NPM][http://npmjs.org/] (included in recent versions of Node.JS)
+* Use `make minify` to minify concatenation result with [UglifyJS2](http://lisperator.net/uglifyjs/).
+* You can also just use `make concat` to obtain an unminified but working version of *sigma.js*, without the need of NPM
 
 ###Thanks
 *sigma.js* is mostly inspired by [Gephi](http://gephi.org) and the maps of [Antonin Rohmer](http://antonin.rohmer.free.fr/) from [Linkfluence](http://labs.linkfluence.net) (one nice example [here](http://www.guardian.co.uk/news/datablog/interactive/2011/sep/07/norway-breivik-manifesto-mapped)) - thanks to him also for his wise advices.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sigma.js",
+  "version": "0.0.1",
+  "devDependencies": {
+    "uglify-js2": ">= 2.1.6"
+  }
+}


### PR DESCRIPTION
Building a Javascript-only project with Java seems over-complicated.

The `Makefile` now uses [UglifyJS2](http://lisperator.net/uglifyjs/) to compress the Javascript. NPM is the only pre-install dependency - `package.json` defines the packages to be locally-installed during the build process.
