### PR TITLE
Fixing GEXF parsing in IE

### DIFF
--- a/plugins/sigma.parseGexf.js
+++ b/plugins/sigma.parseGexf.js
@@ -73,10 +73,12 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
       var x = 100 - 200*Math.random();
       var y = 100 - 200*Math.random();
       var color;
-      
+
+      var poorBrowserXmlNsSupport = (nodeNode.getElementsByTagNameNS == null)
+
       var sizeNodes = nodeNode.getElementsByTagName('size');
-      sizeNodes = sizeNodes.length ? 
-                  sizeNodes : 
+      sizeNodes = sizeNodes.length || poorBrowserXmlNsSupport ?
+                  sizeNodes :
                   nodeNode.getElementsByTagNameNS('*','size');
       if(sizeNodes.length>0){
         sizeNode = sizeNodes[0];
@@ -84,8 +86,8 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
       }
 
       var positionNodes = nodeNode.getElementsByTagName('position');
-      positionNodes = positionNodes.length ? 
-                      positionNodes : 
+      positionNodes = positionNodes.length || poorBrowserXmlNsSupport ?
+                      positionNodes :
                       nodeNode.getElementsByTagNameNS('*','position');
       if(positionNodes.length>0){
         var positionNode = positionNodes[0];
@@ -94,8 +96,8 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
       }
 
       var colorNodes = nodeNode.getElementsByTagName('color');
-      colorNodes = colorNodes.length ? 
-                   colorNodes : 
+      colorNodes = colorNodes.length || poorBrowserXmlNsSupport ?
+                   colorNodes :
                    nodeNode.getElementsByTagNameNS('*','color');
       if(colorNodes.length>0){
         colorNode = colorNodes[0];


### PR DESCRIPTION
IE apparently doesn't support `getElementsByTagNameNS` for XML documents.

This patch simply skips using `getElementsByTagNameNS` when it isn't supported. Any edge cases caught by `getElementsByTagNameNS` will obviously not be caught in IE, but this is probably better behaviour than not working at all.
