### PR TITLE
Provide parseJson plugin (and nothing more)

### DIFF
--- a/plugins/gexf2Json.py
+++ b/plugins/gexf2Json.py
@@ -126,24 +126,22 @@ for edgesNode in edgesNodes:
 	for edgeNode in edgeNodes:
 		source = edgeNode.getAttribute("source")
 		target = edgeNode.getAttribute("target")
-		label = edgeNode.getAttribute("label")
-		id = edgeNode.getAttribute("id") if edgeNode.hasAttribute("id") else edgeId
 		edgeId=edgeId+1
+		size=edgeNode.getAttribute("weight") if nodeEl.hasAttribute("weight") else 1
 
 		edge = {
-		    "id":         id,
 		    "sourceID":   source,
 		    "targetID":   target,
-		    "label":      label,
+		    "size":	size,
 		    "attributes": {}
 		}
 
-		#Anything besies source,target,label that is inside the actual edge tag
+		#Anything besies source,target,weight that is inside the actual edge tag
 		attrs = edgeNode.attributes #NamedNodeMap in python
 		for i in range(0,attrs.length):
 			item=attrs.item(i)#xml.dom.minidom.Attr
 			n=item.name
-			if(n == 'source' or n =='target' or n=='label'):
+			if(n == 'source' or n =='target' or n=='weight' or n=='id'):
 				continue;
 			edge["attributes"][n]=item.value
 
@@ -155,7 +153,12 @@ for edgesNode in edgesNodes:
 		for attvalueNode in attvalueNodes:
 			attr = attvalueNode.getAttribute('for')
 			val = attvalueNode.getAttribute('value')
-			edge["attributes"][edgesAttributesDict[attr]]=val
+			if attr in edgesAttributesDict:
+				attr=edgesAttributesDict[attr]
+			if attr=="weight":
+				edge["size"]=val
+			else:
+				edge["attributes"][attr]=val
 
 		jsonEdges.append(edge)
 

--- a/plugins/sigma.parseGexf.js
+++ b/plugins/sigma.parseGexf.js
@@ -74,7 +74,7 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
       var y = 100 - 200*Math.random();
       var color;
 
-      var poorBrowserXmlNsSupport = (nodeNode.getElementsByTagNameNS == null)
+      var poorBrowserXmlNsSupport = (nodeNode.getElementsByTagNameNS == null);
 
       var sizeNodes = nodeNode.getElementsByTagName('size');
       sizeNodes = sizeNodes.length || poorBrowserXmlNsSupport ?


### PR DESCRIPTION
A fixed minimal addition of two files for adding a parseJSON plugin.

Gexf plugin is not compatible with IE and also creates repeated work by parse xml on every client. Optionally, creators should be able to parse the xml once, store the results in json, and load this

The modifications provide this functionality. The plugin parseJson allows loading a json file of node and edge info. The python script (gexf2json) creates a json file from a gexf file.

The json file loads about .55-.65 seconds faster on localhost and in general has a smaller file size. It is compatible with major browsers (including IE). The json relies on jQuery, which must also be loaded by the user. Finally, the modifications allow a callback function to be passed to parseGexf or parseJson to be executed after data is loaded.

The json structure exactly mirrors the results from parseGexf for compatibility. I would really like, however, to see a dictionary instead of a list for attributes in the future.
