### PR TITLE
Fix adding of edges to graph in pushGraph

### DIFF
--- a/src/core/sigmapublic.js
+++ b/src/core/sigmapublic.js
@@ -150,7 +150,7 @@ function SigmaPublic(sigmaInstance) {
       validID = edge['source'] && edge['target'] && edge['id'];
       validID &&
         (!safe || !s.graph.edgesIndex[edge['id']]) &&
-        self.addNode(
+        self.addEdge(
           edge['id'],
           edge['source'],
           edge['target'],


### PR DESCRIPTION
The issue was that `addNode` was being called instead of `addEdge`.

This fixes issue #76.
