### PR TITLE
Use required edge ID attribute when parsing GEXF

### DIFF
--- a/plugins/sigma.parseGexf.js
+++ b/plugins/sigma.parseGexf.js
@@ -121,18 +121,18 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
   }
 
   var edges = [];
-  var edgeId = 0;
   var edgesNodes = gexf.getElementsByTagName('edges');
   for(i=0; i<edgesNodes.length; i++){
     var edgesNode = edgesNodes[i];
     var edgeNodes = edgesNode.getElementsByTagName('edge');
     for(j=0; j<edgeNodes.length; j++){
       var edgeNode = edgeNodes[j];
+      var id = edgeNode.getAttribute('id');
       var source = edgeNode.getAttribute('source');
       var target = edgeNode.getAttribute('target');
       var label = edgeNode.getAttribute('label');
       var edge = {
-        id:         j,
+        id:         id,
         sourceID:   source,
         targetID:   target,
         label:      label,
@@ -152,7 +152,7 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
         edge.attributes.push({attr:attr, val:val});
       }
 
-      sigmaInstance.addEdge(edgeId++,source,target,edge);
+      sigmaInstance.addEdge(id,source,target,edge);
     }
   }
 };


### PR DESCRIPTION
Both the [1.1draft](http://gexf.net/1.1draft/data.xsd) and [1.2draft](http://gexf.net/1.2draft/data.xsd) schema definitions for GEXF define the `id` attribute of an `edge` element as required. This is what should be used instead of an incrementing ID, for consistency with `pushGraph`, which uses the `id` property of each edge object.

Otherwise, if `pushGraph` is used to push in a graph which contains edges previously added after parsing a GEXF file, duplicate edges will be drawn, as the IDs don't match.
