### PR TITLE
IE doesn't support overrideMimeType

### DIFF
--- a/plugins/sigma.parseGexf.js
+++ b/plugins/sigma.parseGexf.js
@@ -8,7 +8,10 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
     new XMLHttpRequest() :
     new ActiveXObject('Microsoft.XMLHTTP');
 
-  gexfhttp.overrideMimeType('text/xml');
+if (gexfhttp.overrideMimeType) {
+    gexfhttp.overrideMimeType('text/xml');
+}
+
   gexfhttp.open('GET', gexfPath, false);
   gexfhttp.send();
   gexf = gexfhttp.responseXML;


### PR DESCRIPTION
Fixes the GEXF parsing plugin for IE. Without this the script will stop at a hard error on the following line:

``` javascript
gexfhttp.overrideMimeType('text/xml');
```

The fix is to just put it in a block:

``` javascript
if (gexfhttp.overrideMimeType) {
  gexfhttp.overrideMimeType('text/xml');
}
```
