### PR TITLE
Update node index on drop node

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -226,6 +226,11 @@ function Graph() {
       return true;
     });
 
+	// update the node index
+    a.forEach(function(id) {
+    	delete self.nodesIndex[id.toString()];
+    });
+	
     return self;
   };
 


### PR DESCRIPTION
needed to remove nodes from node index on drop node in order to allow
for reinserting nodes back into the graph.
