### PR TITLE
Separated out GEXF parser XHR request from parser itself

### DIFF
--- a/plugins/sigma.parseGexf.js
+++ b/plugins/sigma.parseGexf.js
@@ -16,6 +16,11 @@ sigma.publicPrototype.parseGexf = function(gexfPath) {
   gexfhttp.send();
   gexf = gexfhttp.responseXML;
 
+  return this.parseGexfXmlDoc (gexf);
+};
+
+sigma.publicPrototype.parseGexfXmlDoc = function(gexf) {
+  var sigmaInstance = this;
   var i, j, k;
 
   // Parse Attributes


### PR DESCRIPTION
Hi,

I have code that generates GEXF on-the-fly and so I separated out the GEXF parser, creating a new method that parses an XML document directly (instead of fetching it by an XHR, though you can still call the original method, which is now a wrapper, to do this)

Thanks
Ian
