### PR TITLE
Allow disabling a node's label

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -81,12 +81,12 @@ function Graph() {
         case 'x':
         case 'y':
         case 'size':
+        case 'forceLabel':
           n[k] = +params[k];
           break;
         case 'fixed':
         case 'active':
         case 'hidden':
-        case 'forceLabel':
           n[k] = !!params[k];
           break;
         case 'color':
@@ -156,12 +156,12 @@ function Graph() {
         case 'x':
         case 'y':
         case 'size':
+        case 'forceLabel':
           node[k] = +copy[k];
           break;
         case 'fixed':
         case 'active':
         case 'hidden':
-        case 'forceLabel':
           node[k] = !!copy[k];
           break;
         case 'color':

--- a/src/core/plotter.js
+++ b/src/core/plotter.js
@@ -361,7 +361,8 @@ function Plotter(nodesCtx, edgesCtx, labelsCtx, hoverCtx, graph, w, h) {
   function drawLabel(node) {
     var ctx = labelsCtx;
 
-    if (node['displaySize'] >= self.p.labelThreshold || node['forceLabel']) {
+    if (node['displaySize'] >= self.p.labelThreshold && !(node['forceLabel'] < 0)
+        || node['forceLabel'] > 0) {
       var fontSize = self.p.labelSize == 'fixed' ?
                      self.p.defaultLabelSize :
                      self.p.labelSizeRatio * node['displaySize'];


### PR DESCRIPTION
With this change, you can force a node's label to _not_ be displayed by setting `node['forceLabel']` to a negative value. A slightly inelegant approach, but it worked well for me.
