### PR TITLE
Added edge arrow rendering

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -285,8 +285,7 @@ function Graph() {
           e[k] = +params[k];
           break;
         case 'color':
-          e[k] = params[k].toString();
-          break;
+        case 'arrow':
         case 'type':
           e[k] = params[k].toString();
           break;
@@ -316,6 +315,7 @@ function Graph() {
       'target': edge['target']['id'],
       'size': edge['size'],
       'type': edge['type'],
+      'arrow': edge['arrow'],
       'weight': edge['weight'],
       'displaySize': edge['displaySize'],
       'label': edge['label'],
@@ -354,6 +354,7 @@ function Graph() {
           break;
         case 'color':
         case 'label':
+        case 'arrow':
         case 'type':
           edge[k] = (copy[k] || '').toString();
           break;
@@ -537,9 +538,9 @@ function Graph() {
       node['displaySize'] = node['displaySize'] * sizeRatio;
     });
 
-    sizeRatio = Math.pow(ratio, self.p.edgesPowRatio);
     parseEdges && self.edges.forEach(function(edge) {
-      edge['displaySize'] = edge['displaySize'] * sizeRatio;
+      edge['displaySize'] = edge['displaySize'] * Math.pow(ratio, self.p.edgesPowRatio);
+      edge['arrowDisplaySize'] = edge['displaySize'] * 3 * sizeRatio;     // (edge['displaySize']+1) * 2.5 * sizeRatio;
     });
 
     return self;

--- a/src/public/tools.js
+++ b/src/public/tools.js
@@ -48,6 +48,34 @@ sigma.tools.drawRoundRect = function(ctx, x, y, w, h, ellipse, corners) {
   ctx.lineTo(x, y + e);
 };
 
+/**
+ * Draws a filled arrowhead shape to the corresponding canvas.
+ * @param  {CanvasRenderingContext2D} ctx  The context within which to draw the arrowhead.
+ * @param  {number} x0                     The x-coordinate of the tip of the arrowhead.
+ * @param  {number} y0                     The y-coordinate of the tip of the arrowhead.
+ * @param  {number} size                   The length of the arrowhead.
+ * @param  {number} rotationAngle          The angle of rotation of the arrowhead, in degrees.
+ * @return {undefined} 
+ */
+sigma.tools.drawArrowhead = function(ctx, x0, y0, size, rotationAngle) {
+  var ARROW_SHARPNESS = 22;  // angle between one side of arrowhead and shaft
+
+  ctx.beginPath();
+
+  ctx.moveTo(x0, y0);
+
+  // (Math.PI / 180) === 0.017453292519943295 
+  var x1 = x0 + Math.cos(0.017453292519943295 * (ARROW_SHARPNESS + rotationAngle)) * size; 
+  var y1 = y0 + Math.sin(0.017453292519943295 * (ARROW_SHARPNESS + rotationAngle)) * size; 
+  var x2 = x0 + Math.cos(0.017453292519943295 * (rotationAngle - ARROW_SHARPNESS)) * size; 
+  var y2 = y0 + Math.sin(0.017453292519943295 * (rotationAngle - ARROW_SHARPNESS)) * size; 
+
+  ctx.lineTo(x1, y1);
+  ctx.quadraticCurveTo((x0 + x1 + x2) / 3, (y0 + y1 + y2) / 3, x2, y2);
+  ctx.lineTo(x0, y0);
+  ctx.fill();
+};
+
 sigma.tools.getRGB = function(s, asArray) {
   s = s.toString();
   var res = {
@@ -101,3 +129,14 @@ sigma.tools.toHex = function(n) {
          '0123456789ABCDEF'.charAt(n % 16);
 };
 
+/**
+ * Provides the angle of incidence of the end point of a line or quadratic curve, in degrees. 
+ * @param  {number} x1  The x-coordinate of the start point of the line or control point of the quadratic curve.
+ * @param  {number} y1  The y-coordinate of the start point of the line or control point of the quadratic curve.
+ * @param  {number} x2  The x-coordinate of the line or quadratic curve end point.
+ * @param  {number} y2  The y-coordinate of the line or quadratic curve end point.
+ * @return {number}     Returns the angle of incidence of the end point of the line or quadratic curve cooresponding to the coordinate parms, in degrees.
+ */
+sigma.tools.getIncidenceAngle = function(x1, y1, x2, y2) {
+    return (x1 <= x2 ? 180 : 0) + Math.atan(((y2 - y1) / (x2 - x1))) * 180 / Math.PI;
+};


### PR DESCRIPTION
- Arrowhead location setting can be specified globally in sigma instance drawingProperties (via `defaultEdgeArrow` property) and/or each individual edge (via `arrow` property): **'target', 'source', 'both', 'none'**  _[default]_
- Arrowhead color/size/orientation accommodates edge color/size/type (curved, line)
- Arrowhead tips are drawn at node border (instead of overlapping with nodes)
- Arrowhead display size scales with zoom

Addresses issues: #26, #48 

See demos here:
- http://hansifer.com/sigmaArrowDemo1.htm
- http://hansifer.com/sigmaArrowDemo2.htm
