### PR TITLE
Fix node not being removed from index by dropNode

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -211,7 +211,7 @@ function Graph() {
     });
 
     indexesToRemove.forEach(function(index) {
-      self.nodes.splice(index, 1);
+      delete self.nodesIndex[self.nodes.splice(index, 1)[0]['id']];
     });
 
     self.edges = self.edges.filter(function(e) {


### PR DESCRIPTION
If you call `sigma.pushGraph` with the `safe` parameter set to `true` and a node removed by a previous call to `sigma.dropNode`, the node wouldn't be added because it's never removed from the index by `dropNode`.
