### PR TITLE
fisheye: fix visual glitches during zoom and pan

### DIFF
--- a/plugins/sigma.fisheye.js
+++ b/plugins/sigma.fisheye.js
@@ -51,6 +51,14 @@ sigma.classes.FishEye = function(sig) {
     }
   };
 
+  this.redraw = true;
+
+  sig.mousecaptor.bind("startinterpolate", function() {
+    self.redraw = false;
+  }).bind("stopinterpolate", function() {
+    self.redraw = true;
+  })
+
   this.refresh = function(){};
 };
 
@@ -61,7 +69,7 @@ sigma.publicPrototype.activateFishEye = function() {
     sigmaInstance.fisheye = fe;
 
     fe.refresh = function refresh() {
-      sigmaInstance.draw(2,2,2);
+      if(this.redraw) sigmaInstance.draw(2,2,2);
     };
   }
 


### PR DESCRIPTION
This is a quick and dirty hack to prevent the fisheye plugin triggering updates
while the user is panning and zooming.

It fixed a visual glitch where for about a second after the user has stopped zooming,
moving the mouse causes the edges to flicker. This is because
interpolate events are redrawing the graph with no edges
and the fisheye plugin is redrawing the graph with edges.

This patch is a pretty ugly hack. We need to rethink the internal
API so that plugins have a more cohesive way of trigging
redraws. Also maybe a way to figure out if the use is currently
panning or zooming.

Perhaps with a more complete plugin api, the Pan and Zoom feature
could also become a plugin?

Kind Regards

AK
