### PR TITLE
Fixed bug computing min / max of X and Y axes when rescaling

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -445,12 +445,12 @@ function Graph() {
     weightMax = weightMax || 1;
 
     // Recenter the nodes:
-    var xMin, xMax, yMin, yMax;
+    var xMin = yMin = Infinity, xMax = yMax = Infinity;
     parseNodes && self.nodes.forEach(function(node) {
-      xMax = Math.max(node['x'], xMax || node['x']);
-      xMin = Math.min(node['x'], xMin || node['x']);
-      yMax = Math.max(node['y'], yMax || node['y']);
-      yMin = Math.min(node['y'], yMin || node['y']);
+      xMax = Math.max(node['x'], xMax);
+      xMin = Math.min(node['x'], xMin);
+      yMax = Math.max(node['y'], yMax);
+      yMin = Math.min(node['y'], yMin);
     });
 
     // First, we compute the scaling ratio, without considering the sizes


### PR DESCRIPTION
The previous method would fail in some cases, e.g. if the second to last node in the array had (x, y) = (5, 0), and the last node had (x, y) = (10, 100), then yMin would be 100 instead of 0.
