### PR TITLE
Add concat grunt task and grunt-contrib-concat dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,6 +88,15 @@ module.exports = function(grunt) {
           'build/sigma.min.js': coreJsFiles
         }
       }
+    },
+    concat: {
+      options: {
+        separator: ';'
+      },
+      dist: {
+        src: coreJsFiles,
+        dest: 'build/sigma.js'
+      }
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-closure-linter": "~0.1.4",
     "grunt-contrib-jshint": "~0.7.1",
+    "grunt-contrib-concat": "~0.3.0",
     "load-grunt-tasks": "~0.2.0"
   }
 }


### PR DESCRIPTION
I added a concat task to build a non-minified version of sigma. An example use case is to compile sigma.js together with sigma plugins into a single minfied file.

The drawback is that this adds another dependency grunt-contrib-concat. Not sure how useful this is for the majority of users, it is when you use brunch in your workflow.
