### PR TITLE
Clarification on MDN Function#bind polyfill legal status

### DIFF
--- a/src/utils/sigma.polyfills.js
+++ b/src/utils/sigma.polyfills.js
@@ -41,9 +41,9 @@
     };
 
   /**
-   * Function.prototype.bind polyfill found on MSDN.
-   * Code distributed under the CC Licence:
-   *  > http://creativecommons.org/licenses/by-sa/2.5/
+   * Function.prototype.bind polyfill found on MDN.
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Compatibility
+   * Public domain
    */
   if (!Function.prototype.bind)
     Function.prototype.bind = function(oThis) {


### PR DESCRIPTION
MSDN => MDN : I killed people for less than that ;-)
The code is in [the public domain](https://developer.mozilla.org/en-US/docs/Project:MDN/About)

> Code samples added on or after August 20, 2010 are in the public domain.

(wiki page started on August 26 2010)
