### PR TITLE
Avoid using 'for in' to iterate over arrays.

### DIFF
--- a/src/classes/sigma.classes.dispatcher.js
+++ b/src/classes/sigma.classes.dispatcher.js
@@ -26,6 +26,7 @@
    */
   dispatcher.prototype.bind = function(events, handler) {
     var i,
+        i_end,
         event,
         eArray;
 
@@ -41,7 +42,7 @@
     ) {
       eArray = typeof events === 'string' ? events.split(' ') : events;
 
-      for (i in eArray) {
+      for (i = 0, i_end = eArray.length; i !== i_end; i += 1) {
         event = eArray[i];
 
         // Check that event is not '':
@@ -76,23 +77,26 @@
    */
   dispatcher.prototype.unbind = function(events, handler) {
     var i,
+        i_end,
         j,
+        j_end,
+        k,
         a,
         event,
         eArray = typeof events === 'string' ? events.split(' ') : events;
 
     if (!arguments.length) {
-      for (i in this._handlers)
-        delete this._handlers[i];
+      for (k in this._handlers)
+        delete this._handlers[k];
       return this;
     }
 
     if (handler) {
-      for (i in eArray) {
+      for (i = 0, i_end = eArray.length; i !== i_end; i += 1) {
         event = eArray[i];
         if (this._handlers[event]) {
           a = [];
-          for (j in this._handlers[event])
+          for (j = 0, j_end = this._handlers[event].length; j !== j_end; j += 1)
             if (this._handlers[event][j].handler !== handler)
               a.push(this._handlers[event][j]);
 
@@ -103,7 +107,7 @@
           delete this._handlers[event];
       }
     } else
-      for (i in eArray)
+      for (i = 0, i_end = eArray.length; i !== i_end; i += 1)
         delete this._handlers[eArray[i]];
 
     return this;
@@ -119,7 +123,9 @@
    */
   dispatcher.prototype.dispatchEvent = function(events, data) {
     var i,
+        i_end,
         j,
+        j_end,
         a,
         event,
         eventName,
@@ -128,14 +134,14 @@
 
     data = data === undefined ? {} : data;
 
-    for (i in eArray) {
+    for (i = 0, i_end = eArray.length; i !== i_end; i += 1) {
       eventName = eArray[i];
 
       if (this._handlers[eventName]) {
         event = self.getEvent(eventName, data);
         a = [];
 
-        for (j in this._handlers[eventName]) {
+        for (j = 0, j_end = this._handlers[eventName].length; j !== j_end; j += 1) {
           this._handlers[eventName][j].handler(event);
           if (!this._handlers[eventName][j].one)
             a.push(this._handlers[eventName][j]);

--- a/src/conrad.js
+++ b/src/conrad.js
@@ -137,6 +137,7 @@
    */
   function _bind(events, handler) {
     var i,
+        i_end,
         event,
         eArray;
 
@@ -154,7 +155,7 @@
           events :
           events.split(/ /);
 
-      for (i in eArray) {
+      for (i = 0, i_end = eArray.length; i !== i_end; i += 1) {
         event = eArray[i];
 
         if (!_handlers[event])
@@ -182,7 +183,9 @@
    */
   function _unbind(events, handler) {
     var i,
+        i_end,
         j,
+        j_end,
         a,
         event,
         eArray = Array.isArray(events) ?
@@ -192,11 +195,11 @@
     if (!arguments.length)
       _handlers = Object.create(null);
     else if (handler) {
-      for (i in eArray) {
+      for (i = 0, i_end = eArray.length; i !== i_end; i += 1) {
         event = eArray[i];
         if (_handlers[event]) {
           a = [];
-          for (j in _handlers[event])
+          for (j = 0, j_end = _handlers[event].length; j !== j_end; j += 1)
             if (_handlers[event][j].handler !== handler)
               a.push(_handlers[event][j]);
 
@@ -207,7 +210,7 @@
           delete _handlers[event];
       }
     } else
-      for (i in eArray)
+      for (i = 0, i_end = eArray.length; i !== i_end; i += 1)
         delete _handlers[eArray[i]];
   }
 
@@ -222,6 +225,8 @@
   function _dispatch(events, data) {
     var i,
         j,
+        i_end,
+        j_end,
         event,
         eventName,
         eArray = Array.isArray(events) ?
@@ -230,7 +235,7 @@
 
     data = data === undefined ? {} : data;
 
-    for (i in eArray) {
+    for (i = 0, i_end = eArray.length; i !== i_end; i += 1) {
       eventName = eArray[i];
 
       if (_handlers[eventName]) {
@@ -239,7 +244,7 @@
           data: data || {}
         };
 
-        for (j in _handlers[eventName])
+        for (j = 0, j_end = _handlers[eventName].length; j !== j_end; j += 1)
           try {
             _handlers[eventName][j].handler(event);
           } catch (e) {}


### PR DESCRIPTION
'for in' also iterate over additionnal attributes set on the Array prototype, leading to unexpected
behaviors.
To make sigma.js more defensive against third-party libraries modifying the Array prototype, a more
classic way of iterating is required.

This patch solve issue #183.
