### PR TITLE
adding ability to pass options to forceatlas

### DIFF
--- a/plugins/sigma.layout.forceAtlas2/sigma.layout.forceAtlas2.js
+++ b/plugins/sigma.layout.forceAtlas2/sigma.layout.forceAtlas2.js
@@ -978,12 +978,12 @@
     }
   };
 
-  sigma.prototype.startForceAtlas2 = function() {
+  sigma.prototype.startForceAtlas2 = function(options) {
     if ((this.forceatlas2 || {}).isRunning)
       return this;
 
     if (!this.forceatlas2) {
-      this.forceatlas2 = new forceatlas2.ForceAtlas2(this.graph);
+      this.forceatlas2 = new forceatlas2.ForceAtlas2(this.graph, options || {});
       this.forceatlas2.setAutoSettings();
       this.forceatlas2.init();
     }


### PR DESCRIPTION
A simple change that opens up the ability to pass options to forceAtlas2.  falls back to defaults.
