### PR TITLE
Fixes `gjslint.py does not exist`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,7 @@ module.exports = function(grunt) {
     closureLint: {
       app: {
         closureLinterPath: '/usr/local/bin',
+        command: 'gjslint',
         src: coreJsFiles,
         options: {
           stdout: true,


### PR DESCRIPTION
See https://github.com/wzr1337/grunt-closure-linter/issues/8
