### PR TITLE
dev: make it easier to build for newbies by not requiring global 'grunt-cli'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ git clone git@github.com:jacomyal/sigma.js.git
 
 To build the code:
 
- - Install [Node.js](http://nodejs.org/), [NPM](https://npmjs.org/) and [Grunt](http://gruntjs.com/installing-grunt).
+ - Install [Node.js](http://nodejs.org/).
  - Install [gjslint](https://developers.google.com/closure/utilities/docs/linter_howto?hl=en).
  - Use `npm install` to install sigma development dependencies.
- - Use `grunt uglify` to minify the code with [Uglify](https://github.com/mishoo/UglifyJS). The minified file `sigma.min.js` will then be accessible in the `build/` folder.
+ - Use `npm run build` to minify the code with [Uglify](https://github.com/mishoo/UglifyJS). The minified file `sigma.min.js` will then be accessible in the `build/` folder.
 
 Also, you can customize the build by adding or removing files from the `coreJsFiles` array in `Gruntfile.js` before applying the grunt task.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "grunt-cli": "^0.1.13",
     "grunt": "~0.4.1",
     "grunt-contrib-qunit": "~0.3.0",
     "grunt-contrib-uglify": "~0.2.7",
@@ -23,6 +24,7 @@
   },
   "scripts": {
     "start": "http-server -p 8000",
-    "test": "grunt travis"
+    "test": "grunt travis",
+    "build": "grunt uglify"
   }
 }


### PR DESCRIPTION
adds grunt-cli as devDependency and uses it via 'npm run build'.
