### PR TITLE
Adds ability to define the minimal edge's arrow size.

### DIFF
--- a/src/renderers/canvas/sigma.canvas.edges.arrow.js
+++ b/src/renderers/canvas/sigma.canvas.edges.arrow.js
@@ -24,7 +24,7 @@
         sY = source[prefix + 'y'],
         tX = target[prefix + 'x'],
         tY = target[prefix + 'y'],
-        aSize = thickness * 2.5,
+        aSize = Math.max(thickness * 2.5, settings('minArrowSize')),
         d = Math.sqrt(Math.pow(tX - sX, 2) + Math.pow(tY - sY, 2)),
         aX = sX + (tX - sX) * (d - aSize - tSize) / d,
         aY = sY + (tY - sY) * (d - aSize - tSize) / d,

--- a/src/renderers/canvas/sigma.canvas.edges.curvedArrow.js
+++ b/src/renderers/canvas/sigma.canvas.edges.curvedArrow.js
@@ -28,7 +28,7 @@
                    (source[prefix + 'x'] - target[prefix + 'x']) / 4,
         tX = target[prefix + 'x'],
         tY = target[prefix + 'y'],
-        aSize = thickness * 2.5,
+        aSize = Math.max(thickness * 2.5, settings('minArrowSize')),
         d = Math.sqrt(Math.pow(tX - controlX, 2) + Math.pow(tY - controlY, 2)),
         aX = controlX + (tX - controlX) * (d - aSize - tSize) / d,
         aY = controlY + (tY - controlY) * (d - aSize - tSize) / d,

--- a/src/sigma.settings.js
+++ b/src/sigma.settings.js
@@ -122,6 +122,8 @@
     maxEdgeSize: 1,
     minNodeSize: 1,
     maxNodeSize: 8,
+    // {number} Defines the minimal edge's arrow display size.
+    minArrowSize: 0,
 
 
 


### PR DESCRIPTION
Edge arrows become hard to see when edges size is very small. In this cases definition of minimal arrow size can be very useful.
