### PR TITLE
[ForceAtlas2] Implementation of iteration control (+ config fix)

### DIFF
--- a/plugins/sigma.layout.forceAtlas2/supervisor.js
+++ b/plugins/sigma.layout.forceAtlas2/supervisor.js
@@ -68,8 +68,15 @@
         // Applying layout
         _this.applyLayoutChanges();
 
-        // Send data back to worker and loop
-        _this.sendByteArrayToWorker();
+        // If the number of iterations is over the maximum defined
+        if (typeof _this.config.maxIterations == "number" &&
+                e.data.iterations >= _this.config.maxIterations) {
+          // Finish
+          _this.running = false;
+        } else {
+          // Send data back to worker and loop
+          _this.sendByteArrayToWorker();
+        }
 
         // Rendering graph
         _this.sigInst.refresh();

--- a/plugins/sigma.layout.forceAtlas2/worker.js
+++ b/plugins/sigma.layout.forceAtlas2/worker.js
@@ -48,7 +48,8 @@
         slowDown: 1,
         barnesHutOptimize: false,
         barnesHutTheta: 1.2,
-        barnesHutDepthLimit: 4
+        barnesHutDepthLimit: 4,
+        initialIterations: 0
       }
     };
 
@@ -600,7 +601,8 @@
       sendNewCoords = function() {
         var e = new Event('newCoords');
         e.data = {
-          nodes: W.nodeMatrix.buffer
+          nodes: W.nodeMatrix.buffer,
+          iterations: W.iterations
         };
         requestAnimationFrame(function() {
           document.dispatchEvent(e);
@@ -611,8 +613,10 @@
 
       // From a WebWorker
       sendNewCoords = function() {
-        self.postMessage(
-          {nodes: W.nodeMatrix.buffer},
+        self.postMessage({
+            nodes: W.nodeMatrix.buffer,
+            iterations: W.iterations
+          },
           [W.nodeMatrix.buffer]
         );
       };
@@ -633,6 +637,11 @@
             new Float32Array(e.data.edges),
             e.data.config
           );
+
+          // Initial iterations (if necessary)
+          var initPasses = e.data.config.initialIterations - 1;
+          for(var i = 0 ; i < initPasses ; i++)
+            pass();
 
           // First iteration
           run();


### PR DESCRIPTION
Hiyo,

I've implemented configuration parameters to control the force atlas iterations. In some graphs, the algorithm is unable to converge fast enough even though it's enough for a human ; hence inducing a lot of node flickering and a massive cpu load for nothing. It is not possible to control this outside the layout manager (like in d3's force layout with the tick() method), that's why I've added two new parameters:
- `maxIterations` is the maximum number of FA2 passes to perform (fixes convergence) ; default none
- `initialIterations` is the number of FA2 passes to perform upon starting the worker (fixes random layout display at the beginning) ; default none

Additionally, I've fixed a bug where the configuration was not given to the worker using Supervisor.start.

WydD
