### PR TITLE
Fix for overlapping nodes not being draggable

### DIFF
--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -42,7 +42,7 @@
         _camera = renderer.camera,
         _node = null,
         _prefix = '',
-        _isOverNode = [],
+        _hoverStack = [],
         _isMouseDown = false,
         _isMouseOverCanvas = false;
 
@@ -55,23 +55,23 @@
 
     var nodeMouseOver = function(event) {
       // Add node to array of current nodes over
-      _isOverNode.push(event.data.node);
+      _hoverStack.push(event.data.node);
 
-      if(_isOverNode.length && ! _isMouseDown) {
+      if(_hoverStack.length && ! _isMouseDown) {
         // Set the current node to be the last one in the array
-        _node = _isOverNode[_isOverNode.length - 1];
+        _node = _hoverStack[_hoverStack.length - 1];
         _mouse.addEventListener('mousedown', nodeMouseDown);
       }
     };
 
     var treatOutNode = function(event) {
       // Remove the node from the array
-      var indexCheck = _isOverNode.map(function(e) { return e; }).indexOf(event.data.node);
-      _isOverNode.splice(indexCheck, 1);
+      var indexCheck = _hoverStack.map(function(e) { return e; }).indexOf(event.data.node);
+      _hoverStack.splice(indexCheck, 1);
 
-      if(_isOverNode.length && ! _isMouseDown) {
+      if(_hoverStack.length && ! _isMouseDown) {
         // On out, set the current node to be the next stated in array
-        _node = _isOverNode[_isOverNode.length - 1];
+        _node = _hoverStack[_hoverStack.length - 1];
       } else {
         _mouse.removeEventListener('mousedown', nodeMouseDown);
       }


### PR DESCRIPTION
When two nodes are overlapping, and the cursor is moved from one to the other, outNode is called (leaving the first node) thus disabling the ability to drag the second node (who has already called overNode).

This fix (managing a stack of hovered nodes) will allow you to drag the node that you are currently over, irregardless of overlapping or over/out combinations.

over1, over2, out1 = node2 draggable
over1, over2, out2 = node1 draggable
over1, over2, out2, over3, out3 = node1 draggable
over1, over2, over3, out2, out1 = node3 draggable
etc

The only thing lacking currently is the dragged node being on top all other nodes.
