### PR TITLE
Rework of hover logic to allow a single label to be displayed

### DIFF
--- a/src/misc/sigma.misc.drawHovers.js
+++ b/src/misc/sigma.misc.drawHovers.js
@@ -16,28 +16,21 @@
    */
   sigma.misc.drawHovers = function(prefix) {
     var self = this,
-        hoveredNodes = {};
+      hoveredNodes = [];
 
-    this.bind('overNodes', function(event) {
-      var n = event.data.nodes,
-          l = n.length,
-          i;
-
-      for (i = 0; i < l; i++)
-        hoveredNodes[n[i].id] = n[i];
-
+    this.bind('overNode', function(event) {
+      hoveredNodes.push(event.data.node);
       draw();
     });
-    this.bind('outNodes', function(event) {
-      var n = event.data.nodes,
-          l = n.length,
-          i;
 
-      for (i = 0; i < l; i++)
-        delete hoveredNodes[n[i].id];
-
+    this.bind('outNode', function(event) {
+      var indexCheck = hoveredNodes.map(function(n) {
+        return n;
+      }).indexOf(event.data.node);
+      hoveredNodes.splice(indexCheck, 1);
       draw();
     });
+
     this.bind('render', function(event) {
       draw();
     });
@@ -47,20 +40,37 @@
       self.contexts.hover.canvas.width = self.contexts.hover.canvas.width;
 
       var k,
-          renderers = sigma.canvas.hovers,
-          embedSettings = self.settings.embedObjects({
-            prefix: prefix
-          });
+        renderers = sigma.canvas.hovers,
+        embedSettings = self.settings.embedObjects({
+          prefix: prefix
+        });
 
-      // Render
-      if (embedSettings('enableHovering'))
-        for (k in hoveredNodes)
-          if (!hoveredNodes[k].hidden)
-            (renderers[hoveredNodes[k].type] || renderers.def)(
-              hoveredNodes[k],
+      //Single hover
+      if(embedSettings('enableHovering') && embedSettings('singleHover') && hoveredNodes.length) {
+        if(! hoveredNodes[hoveredNodes.length - 1].hidden) {
+          (renderers[hoveredNodes[hoveredNodes.length - 1].type] || renderers.def)(
+            hoveredNodes[hoveredNodes.length - 1],
+            self.contexts.hover,
+            embedSettings
+          );
+        }
+      }
+
+      //Multiple hover
+      if(embedSettings('enableHovering') && !embedSettings('singleHover') && hoveredNodes.length) {
+        for(var i=0; i<hoveredNodes.length; i++) {
+          console.log('yep');
+          if(! hoveredNodes[i].hidden) {
+            (renderers[hoveredNodes[i].type] || renderers.def)(
+              hoveredNodes[i],
               self.contexts.hover,
               embedSettings
             );
+          }
+        }
+      }
+
+
     }
   };
 }).call(this);

--- a/src/renderers/canvas/sigma.canvas.hovers.def.js
+++ b/src/renderers/canvas/sigma.canvas.hovers.def.js
@@ -16,16 +16,16 @@
    */
   sigma.canvas.hovers.def = function(node, context, settings) {
     var x,
-        y,
-        w,
-        h,
-        e,
-        fontStyle = settings('hoverFontStyle') || settings('fontStyle'),
-        prefix = settings('prefix') || '',
-        size = node[prefix + 'size'],
-        fontSize = (settings('labelSize') === 'fixed') ?
-          settings('defaultLabelSize') :
-          settings('labelSizeRatio') * size;
+      y,
+      w,
+      h,
+      e,
+      fontStyle = settings('hoverFontStyle') || settings('fontStyle'),
+      prefix = settings('prefix') || '',
+      size = node[prefix + 'size'],
+      fontSize = (settings('labelSize') === 'fixed') ?
+        settings('defaultLabelSize') :
+        settings('labelSizeRatio') * size;
 
     // Label background:
     context.font = (fontStyle ? fontStyle + ' ' : '') +
@@ -36,18 +36,18 @@
       (node.color || settings('defaultNodeColor')) :
       settings('defaultHoverLabelBGColor');
 
-    if (settings('labelHoverShadow')) {
+    if (node.label && settings('labelHoverShadow')) {
       context.shadowOffsetX = 0;
       context.shadowOffsetY = 0;
       context.shadowBlur = 8;
       context.shadowColor = settings('labelHoverShadowColor');
     }
 
-    if (typeof node.label === 'string') {
+    if (node.label && typeof node.label === 'string') {
       x = Math.round(node[prefix + 'x'] - fontSize / 2 - 2);
       y = Math.round(node[prefix + 'y'] - fontSize / 2 - 2);
       w = Math.round(
-        context.measureText(node.label).width + fontSize / 2 + size + 7
+          context.measureText(node.label).width + fontSize / 2 + size + 7
       );
       h = Math.round(fontSize + 4);
       e = Math.round(fontSize / 2 + 2);
@@ -77,9 +77,9 @@
       context.arc(
         node[prefix + 'x'],
         node[prefix + 'y'],
-        size + settings('borderSize'),
+          size + settings('borderSize'),
         0,
-        Math.PI * 2,
+          Math.PI * 2,
         true
       );
       context.closePath();


### PR DESCRIPTION
Similar to pull request #293, this reworks the hover logic to allow users to specify only wanting to see a single label, rather than all the labels of nodes currently hovered on.

This is allowed via the setting: `singleHover: true`. Feel free to rename as you wish.
