### PR TITLE
Add option to use initial scale to disable graph resize compensation on node drag

### DIFF
--- a/examples/drag-nodes.html
+++ b/examples/drag-nodes.html
@@ -33,6 +33,8 @@
 <script src="../src/misc/sigma.misc.drawHovers.js"></script>
 <!-- END SIGMA IMPORTS -->
 <script src="../plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js"></script>
+<script src="../plugins/sigma.layout.forceAtlas2/worker.js"></script>
+<script src="../plugins/sigma.layout.forceAtlas2/supervisor.js"></script>
 <div id="container">
   <style>
     #graph-container {
@@ -91,4 +93,9 @@ s = new sigma({
 
 // Initialize the dragNodes plugin:
 sigma.plugins.dragNodes(s, s.renderers[0]);
+
+s.startForceAtlas2();
+setTimeout(function() {
+  s.killForceAtlas2();
+},2000)
 </script>

--- a/examples/drag-nodes.html
+++ b/examples/drag-nodes.html
@@ -81,7 +81,12 @@ sigma.renderers.def = sigma.renderers.canvas
 // Instanciate sigma:
 s = new sigma({
   graph: g,
-  container: 'graph-container'
+  container: 'graph-container',
+  settings: {
+    fixedScaling: true,
+    zoomMin: 0,
+    zoomMax: 100
+  }
 });
 
 // Initialize the dragNodes plugin:

--- a/src/middlewares/sigma.middlewares.rescale.js
+++ b/src/middlewares/sigma.middlewares.rescale.js
@@ -61,7 +61,7 @@
         h / Math.max(maxY - minY, 1)
       );
 
-    setTimeout(function() { if(settings('fixedScaling') && !_this.graph.initScale && !_this.isForceAtlas2Running()) _this.graph.initScale = scale },50);
+    setTimeout(function() { if(settings('fixedScaling') && !_this.graph.initScale && !_this.isForceAtlas2Running()) _this.graph.initScale = scale });
 
     /**
      * Then, we correct that scaling ratio considering a margin, which is
@@ -93,7 +93,7 @@
         h / Math.max(maxY - minY, 1)
       );
 
-    setTimeout(function() { if(settings('fixedScaling') && !_this.graph.initScale && !_this.isForceAtlas2Running()) _this.graph.initScale = scale },50);
+    setTimeout(function() { if(settings('fixedScaling') && !_this.graph.initScale && !_this.isForceAtlas2Running()) _this.graph.initScale = scale });
 
     // Size homothetic parameters:
     if (!settings('maxNodeSize') && !settings('minNodeSize')) {

--- a/src/middlewares/sigma.middlewares.rescale.js
+++ b/src/middlewares/sigma.middlewares.rescale.js
@@ -60,6 +60,8 @@
         h / Math.max(maxY - minY, 1)
       );
 
+    if(settings('fixedScaling') && !this.graph.initScale) this.graph.initScale = scale;
+
     /**
      * Then, we correct that scaling ratio considering a margin, which is
      * basically the size of the biggest node.
@@ -89,6 +91,8 @@
         w / Math.max(maxX - minX, 1),
         h / Math.max(maxY - minY, 1)
       );
+
+    if(settings('fixedScaling') && !this.graph.initScale) this.graph.initScale = scale;
 
     // Size homothetic parameters:
     if (!settings('maxNodeSize') && !settings('minNodeSize')) {
@@ -120,9 +124,9 @@
     for (i = 0, l = n.length; i < l; i++) {
       n[i][writePrefix + 'size'] = n[i][readPrefix + 'size'] * a + b;
       n[i][writePrefix + 'x'] =
-        (n[i][readPrefix + 'x'] - (maxX + minX) / 2) * scale;
+        (n[i][readPrefix + 'x'] - (maxX + minX) / 2) * (this.graph.initScale || scale);
       n[i][writePrefix + 'y'] =
-        (n[i][readPrefix + 'y'] - (maxY + minY) / 2) * scale;
+        (n[i][readPrefix + 'y'] - (maxY + minY) / 2) * (this.graph.initScale || scale);
     }
   };
 

--- a/src/middlewares/sigma.middlewares.rescale.js
+++ b/src/middlewares/sigma.middlewares.rescale.js
@@ -20,7 +20,8 @@
    * @param {object}  options     The parameters.
    */
   sigma.middlewares.rescale = function(readPrefix, writePrefix, options) {
-    var i,
+    var _this = this,
+        i,
         l,
         a,
         b,
@@ -60,7 +61,7 @@
         h / Math.max(maxY - minY, 1)
       );
 
-    if(settings('fixedScaling') && !this.graph.initScale) this.graph.initScale = scale;
+    setTimeout(function() { if(settings('fixedScaling') && !_this.graph.initScale && !_this.isForceAtlas2Running()) _this.graph.initScale = scale },50);
 
     /**
      * Then, we correct that scaling ratio considering a margin, which is
@@ -92,7 +93,7 @@
         h / Math.max(maxY - minY, 1)
       );
 
-    if(settings('fixedScaling') && !this.graph.initScale) this.graph.initScale = scale;
+    setTimeout(function() { if(settings('fixedScaling') && !_this.graph.initScale && !_this.isForceAtlas2Running()) _this.graph.initScale = scale },50);
 
     // Size homothetic parameters:
     if (!settings('maxNodeSize') && !settings('minNodeSize')) {


### PR DESCRIPTION
Added option to disable the graph collapsing (resizing / zooming out) into two points when dragging a node beyond the graph boundaries. `fixedScaling: true` Will enable the user to drag a node around without the graph resizing to compensate.

(feel free to rename setting name!)

This fixes issue #256.

**EDIT:** Found I had to compensate for ForceAtlas2 usage - and unfortunately, `isForceAtlas2Running()` returns `null` initially, hence the dirty dirty `timeout` : (, there must be a better way...
