### PR TITLE
Fixed buggy drag behaviour when container is offset.

### DIFF
--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -52,6 +52,19 @@
       _prefix = renderer.options.prefix;
     }
 
+    // Calculates the global offset of the given element more accurately than
+    // element.offsetTop and element.offsetLeft.
+    var calculateOffset = function(element) {
+      var style = window.getComputedStyle(element);
+      var getCssProperty = function(prop) {
+        return parseInt(style.getPropertyValue(prop).replace('px', '')) || 0;
+      };
+      return {
+        left: element.getBoundingClientRect().left + getCssProperty('padding-left'),
+        top: element.getBoundingClientRect().top + getCssProperty('padding-top')
+      };
+    };
+
     var nodeMouseOver = function(event) {
       if (!_isOverNode) {
         _node = event.data.node;
@@ -96,8 +109,9 @@
     };
 
     var nodeMouseMove = function(event) {
-      var x = event.pageX - _container.offsetLeft,
-          y = event.pageY - _container.offsetTop,
+      var offset = calculateOffset(_container),
+          x = event.pageX - offset.left,
+          y = event.pageY - offset.top,
           cos = Math.cos(_camera.angle),
           sin = Math.sin(_camera.angle),
           nodes = s.graph.nodes(),


### PR DESCRIPTION
If _container is offset from the top-left corner of the page, it is very easy for local/global mouse position errors to creep into calculations. In particular, when dragging a node it hovers a fixed distance away from the mouse. This more robust calculation fixes these issues (including padding which is independent of the bounding rect), and allows the container to be placed anywhere with any offset/margin/padding, and it need not be position: absolute.
