### PR TITLE
fixes build for the forceAtlas2 plugin

### DIFF
--- a/plugins/sigma.layout.forceAtlas2/tasks/forceAtlas2.js
+++ b/plugins/sigma.layout.forceAtlas2/tasks/forceAtlas2.js
@@ -58,8 +58,8 @@ function crush(fnString) {
 // Cleaning function
 function clean(string) {
   return string.replace(
-    /function crush\(fnString\) \{[\s\S]*sigma\.prototype\.getForceAtlas2Worker/,
-    'var crush = null; sigma.prototype.getForceAtlas2Worker'
+    /function crush\(fnString\)/,
+    'var crush = null; function no_crush(fnString)'
   );
 }
 


### PR DESCRIPTION
Since 104498523faed663910 the clean function wasn't working correctly: the different structure of the code after the crush function in worker.js was making the regexp remove too much, which resulted in uglify generating an empty source.
I've fixed it by adding a comment "marker" after crush's closing brace  and using that in the regexp.
