### PR TITLE
Improve plugins.dragNodes

### DIFF
--- a/examples/drag-nodes.html
+++ b/examples/drag-nodes.html
@@ -48,8 +48,19 @@
       right: 0;
       position: absolute;
     }
+
+    #sidebar {
+      bottom: 0;
+      right: 0;
+      width: 200px;
+      height: 150px;
+      position: absolute;
+      background-color: #999;
+      padding: 10px;
+    }
   </style>
   <div id="graph-container"></div>
+  <div id="sidebar">This area is not a drop target.</div>
 </div>
 <script>
 /**
@@ -91,5 +102,18 @@ s = new sigma({
 });
 
 // Initialize the dragNodes plugin:
-sigma.plugins.dragNodes(s, s.renderers[0]);
+var dragListener = sigma.plugins.dragNodes(s, s.renderers[0]);
+
+dragListener.bind('startdrag', function(event) {
+  console.log(event);
+});
+dragListener.bind('drag', function(event) {
+  console.log(event);
+});
+dragListener.bind('drop', function(event) {
+  console.log(event);
+});
+dragListener.bind('dragend', function(event) {
+  console.log(event);
+});
 </script>

--- a/plugins/sigma.plugins.dragNodes/README.md
+++ b/plugins/sigma.plugins.dragNodes/README.md
@@ -1,8 +1,36 @@
 sigma.plugins.dragNodes
 =====================
 
-Plugin developed by [José M. Camacho](https://github.com/josemazo).
+Plugin developed by [José M. Camacho](https://github.com/josemazo), events by [Sébastien Heymann](https://github.com/sheymann) for [Linkurious](https://github.com/Linkurious).
 
 ---
 
-This plugin provides a method to drag & drop nodes. At the moment, this plugin is not compatible with the WebGL renderer. Check the sigma.plugins.dragNodes function doc or the examples/drag-nodes.html code sample to know more.
+This plugin provides a method to drag & drop nodes. At the moment, this plugin is not compatible with the WebGL renderer. Check the sigma.plugins.dragNodes function doc or the [example code](../../examples/drag-nodes.html) to know more.
+
+To use, include all .js files under this folder. Then initialize it as follows:
+
+````javascript
+var dragListener = new sigma.plugins.dragNodes(sigInst, renderer);
+````
+
+Kill the plugin as follows:
+
+````javascript
+sigma.plugins.killDragNodes();
+````
+
+## Events
+
+This plugin provides the following events fired by the instance of the plugin:
+* `startdrag`: fired at the beginning of the drag
+* `drag`: fired while the node is dragged
+* `drop`: fired at the end of the drag if the node has been dragged
+* `dragend`: fired at the end of the drag
+
+Exemple of event binding:
+
+````javascript
+dragListener.bind('startdrag', function(event) {
+  console.log(event);
+});
+````

--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -11,6 +11,7 @@
 
   sigma.utils.pkg('sigma.plugins');
 
+
   /**
    * This function will add `mousedown`, `mouseup` & `mousemove` events to the
    * nodes in the `overNode`event to perform drag & drop operations. It uses
@@ -20,12 +21,21 @@
    * attributes. These attributes represent the coordinates of the nodes in
    * the real container, not in canvas.
    *
+   * Fired events:
+   * *************
+   * startdrag  Fired at the beginning of the drag.
+   * drag       Fired while the node is dragged.
+   * drop       Fired at the end of the drag if the node has been dragged.
+   * dragend    Fired at the end of the drag.
+   *
    * Recognized parameters:
    * **********************
    * @param  {sigma}    s        The related sigma instance.
    * @param  {renderer} renderer The related renderer instance.
    */
-  sigma.plugins.dragNodes = function(s, renderer) {
+  function DragNodes(s, renderer) {
+    sigma.classes.dispatcher.extend(this);
+
     // A quick hardcoded rule to prevent people from using this plugin with the
     // WebGL renderer (which is impossible at the moment):
     if (
@@ -36,15 +46,20 @@
         'The sigma.plugins.dragNodes is not compatible with the WebGL renderer'
       );
 
-    var _body = document.body,
-        _container = renderer.container,
-        _mouse = _container.lastChild,
-        _camera = renderer.camera,
-        _node = null,
-        _prefix = '',
-        _hoverStack = [],
-        _isMouseDown = false,
-        _isMouseOverCanvas = false;
+    // Init variables:
+    var _self = this,
+      _s = s,
+      _body = document.body,
+      _renderer = renderer,
+      _mouse = renderer.container.lastChild,
+      _camera = renderer.camera,
+      _node = null,
+      _prefix = '',
+      _hoverStack = [],
+      _hoverIndex = {},
+      _isMouseDown = false,
+      _isMouseOverCanvas = false,
+      _drag = false;
 
     // It removes the initial substring ('read_') if it's a WegGL renderer.
     if (renderer instanceof sigma.renderers.webgl) {
@@ -53,9 +68,28 @@
       _prefix = renderer.options.prefix;
     }
 
+    renderer.bind('overNode', nodeMouseOver);
+    renderer.bind('outNode', treatOutNode);
+    renderer.bind('click', click);
+
+    _s.bind('kill', function() {
+      _self.unbindAll();
+    });
+
+    /**
+     * Unbind all event listeners.
+     */
+    this.unbindAll = function() {
+      _mouse.removeEventListener('mousedown', nodeMouseDown);
+      _body.removeEventListener('mousemove', nodeMouseMove);
+      _body.removeEventListener('mouseup', nodeMouseUp);
+      _renderer.unbind('overNode', nodeMouseOver);
+      _renderer.unbind('outNode', treatOutNode);
+    }
+
     // Calculates the global offset of the given element more accurately than
     // element.offsetTop and element.offsetLeft.
-    var calculateOffset = function(element) {
+    function calculateOffset(element) {
       var style = window.getComputedStyle(element);
       var getCssProperty = function(prop) {
         return parseInt(style.getPropertyValue(prop).replace('px', '')) || 0;
@@ -66,9 +100,26 @@
       };
     };
 
-    var nodeMouseOver = function(event) {
+    function click(event) {
+      // event triggered at the end of the click
+      _isMouseDown = false;
+      _body.removeEventListener('mousemove', nodeMouseMove);
+      _body.removeEventListener('mouseup', nodeMouseUp);
+
+      if (!_hoverStack.length) {
+        _node = null;
+      }
+    };
+
+    function nodeMouseOver(event) {
+      // Don't treat the node if it is already registered
+      if (_hoverIndex[event.data.node.id]) {
+        return;
+      }
+
       // Add node to array of current nodes over
       _hoverStack.push(event.data.node);
+      _hoverIndex[event.data.node.id] = true;
 
       if(_hoverStack.length && ! _isMouseDown) {
         // Set the current node to be the last one in the array
@@ -77,10 +128,11 @@
       }
     };
 
-    var treatOutNode = function(event) {
+    function treatOutNode(event) {
       // Remove the node from the array
       var indexCheck = _hoverStack.map(function(e) { return e; }).indexOf(event.data.node);
       _hoverStack.splice(indexCheck, 1);
+      delete _hoverIndex[event.data.node.id];
 
       if(_hoverStack.length && ! _isMouseDown) {
         // On out, set the current node to be the next stated in array
@@ -90,10 +142,10 @@
       }
     };
 
-    var nodeMouseDown = function(event) {
+    function nodeMouseDown(event) {
       _isMouseDown = true;
-      var size = s.graph.nodes().length;
-      if (size > 1) {
+      var size = _s.graph.nodes().length;
+      if (_node && size > 0) {
         _mouse.removeEventListener('mousedown', nodeMouseDown);
         _body.addEventListener('mousemove', nodeMouseMove);
         _body.addEventListener('mouseup', nodeMouseUp);
@@ -101,20 +153,26 @@
         // Do not refresh edgequadtree during drag:
         var k,
             c;
-        for (k in s.cameras) {
-          c = s.cameras[k];
+        for (k in _s.cameras) {
+          c = _s.cameras[k];
           if (c.edgequadtree !== undefined) {
             c.edgequadtree._enabled = false;
           }
         }
 
         // Deactivate drag graph.
-        renderer.settings({mouseEnabled: false, enableHovering: false});
-        s.refresh();
+        _renderer.settings({mouseEnabled: false, enableHovering: false});
+        _s.refresh();
+
+        _self.dispatchEvent('startdrag', {
+          node: _node,
+          captor: event,
+          renderer: _renderer
+        });
       }
     };
 
-    var nodeMouseUp = function(event) {
+    function nodeMouseUp(event) {
       _isMouseDown = false;
       _mouse.addEventListener('mousedown', nodeMouseDown);
       _body.removeEventListener('mousemove', nodeMouseMove);
@@ -123,19 +181,35 @@
       // Allow to refresh edgequadtree:
       var k,
           c;
-      for (k in s.cameras) {
-        c = s.cameras[k];
+      for (k in _s.cameras) {
+        c = _s.cameras[k];
         if (c.edgequadtree !== undefined) {
           c.edgequadtree._enabled = true;
         }
       }
 
       // Activate drag graph.
-      renderer.settings({mouseEnabled: true, enableHovering: true});
-      s.refresh();
+      _renderer.settings({mouseEnabled: true, enableHovering: true});
+      _s.refresh();
+
+      if (_drag) {
+        _self.dispatchEvent('drop', {
+          node: _node,
+          captor: event,
+          renderer: _renderer
+        });
+      }
+      _self.dispatchEvent('dragend', {
+        node: _node,
+        captor: event,
+        renderer: _renderer
+      });
+      
+      _drag = false;
+      _node = null;
     };
 
-    var nodeMouseMove = function(event) {
+    function nodeMouseMove(event) {
       if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
         clearTimeout(timeOut);
         var timeOut = setTimeout(executeNodeMouseMove, 0);
@@ -144,12 +218,12 @@
       }
 
       function executeNodeMouseMove() {
-        var offset = calculateOffset(_container),
+        var offset = calculateOffset(_renderer.container),
             x = event.clientX - offset.left,
             y = event.clientY - offset.top,
             cos = Math.cos(_camera.angle),
             sin = Math.sin(_camera.angle),
-            nodes = s.graph.nodes(),
+            nodes = _s.graph.nodes(),
             ref = [];
 
         // Getting and derotating the reference coordinates.
@@ -174,12 +248,53 @@
         _node.x = x * cos - y * sin;
         _node.y = y * cos + x * sin;
 
-        s.refresh();
+        _s.refresh();
+
+        _drag = true;
+        _self.dispatchEvent('drag', {
+          node: _node,
+          captor: event,
+          renderer: _renderer
+        });
       }
     };
+  };
 
-    renderer.bind('overNode', nodeMouseOver);
-    renderer.bind('outNode', treatOutNode);
+  /**
+   * Interface
+   * ------------------
+   *
+   * > var dragNodesListener = sigma.plugins.dragNodes(s, s.renderers[0]);
+   */
+  var _instance = {};
+
+  /**
+   * @param  {sigma} s The related sigma instance.
+   * @param  {renderer} renderer The related renderer instance.
+   */
+  sigma.plugins.dragNodes = function(s, renderer) {
+    // Create object if undefined
+    if (!_instance[s.id]) {
+      _instance[s.id] = new DragNodes(s, renderer);
+    }
+
+    s.bind('kill', function() {
+      delete _instance[s.id];
+    });
+
+    return _instance[s.id];
+  };
+
+  /**
+   * This method removes the event listeners and kills the dragNodes instance.
+   *
+   * @param  {sigma} s The related sigma instance.
+   */
+  sigma.plugins.killDragNodes = function(s) {
+    if (_instance[s.id] instanceof DragNodes) {
+      _instance[s.id].unbindAll();
+      delete _instance[s.id];
+    }
   };
 
 }).call(window);


### PR DESCRIPTION
Prevent a node to be added multiple times on the stack, which can generate bugs for third-party plugins.

Adds drag events for integration with third-party tools.
