### PR TITLE
fix edgehover bug when hovering arrow type edges

### DIFF
--- a/src/renderers/canvas/sigma.canvas.edgehovers.arrow.js
+++ b/src/renderers/canvas/sigma.canvas.edgehovers.arrow.js
@@ -19,15 +19,13 @@
         edgeColor = settings('edgeColor'),
         defaultNodeColor = settings('defaultNodeColor'),
         defaultEdgeColor = settings('defaultEdgeColor'),
-        size = edge[prefix + 'size'] || 1,
+        size = settings('edgeHoverSizeRatio')*(edge[prefix + 'size'] || 1),
         tSize = target[prefix + 'size'],
         sX = source[prefix + 'x'],
         sY = source[prefix + 'y'],
         tX = target[prefix + 'x'],
         tY = target[prefix + 'y'];
 
-    size = (edge.hover) ?
-      settings('edgeHoverSizeRatio') * size : size;
     var aSize = size * 2.5,
         d = Math.sqrt(Math.pow(tX - sX, 2) + Math.pow(tY - sY, 2)),
         aX = sX + (tX - sX) * (d - aSize - tSize) / d,


### PR DESCRIPTION
The size of edges did not look like what I expected when I hovered on the arrow edges, but it looked fine when I hover on the curve and curvedArrow edges. So I looked into the source code in `src/renderers/canvas/sigma.canvas.edgehovers.arrow.js`. I removed the code of `edge.hover` because it did not show in `../curve.js` or `../curvedArrow.js`. The size looks fine again. It seems that the value of `edge.hover` turns out always to be `false`.
