### PR TITLE
SVG: renderer does not create node labels for IE 9

### DIFF
--- a/src/renderers/svg/sigma.svg.hovers.def.js
+++ b/src/renderers/svg/sigma.svg.hovers.def.js
@@ -55,6 +55,7 @@
 
         // Text
         text.innerHTML = node.label;
+        text.textContent =  node.label;
         text.setAttributeNS(null, 'font-size', fontSize);
         text.setAttributeNS(null, 'font-family', settings('font'));
         text.setAttributeNS(null, 'fill', fontColor);

--- a/src/renderers/svg/sigma.svg.labels.def.js
+++ b/src/renderers/svg/sigma.svg.labels.def.js
@@ -38,6 +38,7 @@
       text.setAttributeNS(null, 'fill', fontColor);
 
       text.innerHTML = node.label;
+      text.textContent = node.label;
 
       return text;
     },


### PR DESCRIPTION
IE 9 does not support innerHTML
