### PR TITLE
SVG: outNode issue for Firefox

### DIFF
--- a/src/misc/sigma.misc.bindDOMEvents.js
+++ b/src/misc/sigma.misc.bindDOMEvents.js
@@ -115,7 +115,7 @@
 
     // On out
     function onOut(e) {
-      var target = e.fromElement || e.relatedTarget;
+      var target = e.fromElement || e.originalTarget;
 
       if (!self.settings('eventsEnabled'))
         return;


### PR DESCRIPTION
relatedTarget is the final target in mouseout event
originalTarget is the source target in mouseout event
https://developer.mozilla.org/en-US/docs/Web/API/event.relatedTarget
