### PR TITLE
fix defaultNodeHoverColor setting does not take effect in canvas render

### DIFF
--- a/src/renderers/canvas/sigma.canvas.hovers.def.js
+++ b/src/renderers/canvas/sigma.canvas.hovers.def.js
@@ -87,8 +87,20 @@
     }
 
     // Node:
-    var nodeRenderer = sigma.canvas.nodes[node.type] || sigma.canvas.nodes.def;
-    nodeRenderer(node, context, settings);
+    context.fillStyle = settings('nodeHoverColor') === 'node' ?
+      (node.color || settings('defaultNodeColor')) :
+      settings('defaultNodeHoverColor');
+    context.beginPath();
+    context.arc(
+      node[prefix + 'x'],
+      node[prefix + 'y'],
+      node[prefix + 'size'],
+      0,
+      Math.PI * 2,
+      true
+    );
+    context.closePath();
+    context.fill();
 
     // Display the label:
     if (typeof node.label === 'string') {


### PR DESCRIPTION
When I set `nodeHoverColor` with value of `default` and `defaultNodeHoverColor` with value of `#00ff00`, the node did not change. The updated code works fine.
