### PR TITLE
SVG: remove _s.refresh in mouseup callback in dragNode plugin

### DIFF
--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -190,7 +190,6 @@
 
       // Activate drag graph.
       _renderer.settings({mouseEnabled: true, enableHovering: true});
-      _s.refresh();
 
       if (_drag) {
         _self.dispatchEvent('drop', {


### PR DESCRIPTION
This causes svg renderer to fail to catch the click event when the mouse hovers over a node and clicks on the node for the first time. It only happens on chrome. Tested both canvas and svg renderers and they all work properly.