### PR TITLE
SVG: add Label alignment settings

### DIFF
--- a/src/renderers/sigma.renderers.svg.js
+++ b/src/renderers/sigma.renderers.svg.js
@@ -313,9 +313,8 @@
     this.container.appendChild(canvas);
     this.measurementCanvas = canvas.getContext('2d');
 
-    var fontSize = (this.settings('labelSize') === 'fixed') ?
-      this.settings('defaultLabelSize') :
-      this.settings('labelSizeRatio') * size;
+    // "proportional" labelSize is not yet supported
+    var fontSize = this.settings('defaultLabelSize');
     this.measurementCanvas.font = (this.settings('fontStyle') ?
       this.settings('fontStyle') + ' ' :
       '') + fontSize + 'px ' + this.settings('font');

--- a/src/renderers/sigma.renderers.svg.js
+++ b/src/renderers/sigma.renderers.svg.js
@@ -219,6 +219,7 @@
         (subrenderers[a[i].type] || subrenderers.def).update(
           a[i],
           this.domElements.labels[a[i].id],
+          this.measurementCanvas,
           embedSettings
         );
       }
@@ -311,6 +312,13 @@
     // Appending measurement canvas
     this.container.appendChild(canvas);
     this.measurementCanvas = canvas.getContext('2d');
+
+    var fontSize = (this.settings('labelSize') === 'fixed') ?
+      this.settings('defaultLabelSize') :
+      this.settings('labelSizeRatio') * size;
+    this.measurementCanvas.font = (this.settings('fontStyle') ?
+      this.settings('fontStyle') + ' ' :
+      '') + fontSize + 'px ' + this.settings('font');
   };
 
   /**

--- a/src/renderers/svg/sigma.svg.hovers.def.js
+++ b/src/renderers/svg/sigma.svg.hovers.def.js
@@ -31,6 +31,8 @@
           h,
           e,
           d,
+          alignment,
+          labelWidth,
           fontStyle = settings('hoverFontStyle') || settings('fontStyle'),
           prefix = settings('prefix') || '',
           size = node[prefix + 'size'],
@@ -51,61 +53,104 @@
       group.setAttributeNS(null, 'class', settings('classPrefix') + '-hover');
       group.setAttributeNS(null, 'data-node-id', node.id);
 
-      if (typeof node.label === 'string') {
+      if (node.label && typeof node.label === 'string') {
+        if (settings('labelAlignment') === undefined) {
+          alignment = settings('defaultLabelAlignment');
+        } else {
+          alignment = settings('labelAlignment');
+        }
+
+        // Measures
+        // OPTIMIZE: Find a better way than a measurement canvas
+        x = Math.round(node[prefix + 'x']);
+        y = Math.round(node[prefix + 'y']);
+        labelWidth = measurementCanvas.measureText(node.label).width;
+        w = Math.round(
+          labelWidth + size + 1.5 + fontSize / 3
+        );
+        h = Math.round(fontSize + 4);
+        e = size + fontSize / 3;
+
+        // update x and y positions of rectangle and label
+        switch (alignment) {
+          case 'center':
+            text.setAttributeNS(null, 'x', x - labelWidth / 2);
+            text.setAttributeNS(null, 'y', y + fontSize / 3);
+            break;
+          case 'left':
+            text.setAttributeNS(null, 'x', x - size - 3 - labelWidth);
+            text.setAttributeNS(null, 'y', y + fontSize / 3);
+            rectangle.setAttributeNS(null, 'x', x - w);
+            rectangle.setAttributeNS(null, 'y', y - fontSize / 2 - 2);
+            break;
+          case 'top':
+            text.setAttributeNS(null, 'x', x - labelWidth / 2);
+            text.setAttributeNS(null, 'y', y - size - 2 * fontSize / 3);
+            rectangle.setAttributeNS(null, 'x', x - w / 2);
+            rectangle.setAttributeNS(null, 'y', y - e);
+            break;
+          case 'bottom':
+            text.setAttributeNS(null, 'x', x - labelWidth / 2);
+            text.setAttributeNS(null, 'y', y + size + 4 * fontSize / 3);
+            rectangle.setAttributeNS(null, 'x', x - w / 2);
+            rectangle.setAttributeNS(null, 'y', y + e);
+            break;
+          case 'inside':
+            if (labelWidth <= e * 2) {
+              text.setAttributeNS(null, 'x', x - labelWidth / 2);
+              text.setAttributeNS(null, 'y', y + fontSize / 3);
+              break;
+            }
+            /* falls through */
+          case 'right':
+            /* falls through */
+          default:
+            text.setAttributeNS(null, 'x', x + size + 3);
+            text.setAttributeNS(null, 'y', y + fontSize / 3);
+            rectangle.setAttributeNS(null, 'x', x);
+            rectangle.setAttributeNS(null, 'y', y - fontSize / 2 - 2);
+            break;
+        }
 
         // Text
         text.innerHTML = node.label;
         text.textContent = node.label;
         text.setAttributeNS(
-            null,
-            'class',
-            settings('classPrefix') + '-hover-label');
+          null,
+          'class',
+          settings('classPrefix') + '-hover-label');
         text.setAttributeNS(null, 'font-size', fontSize);
         text.setAttributeNS(null, 'font-family', settings('font'));
         text.setAttributeNS(null, 'fill', fontColor);
-        text.setAttributeNS(null, 'x',
-          Math.round(node[prefix + 'x'] + size + 3));
-        text.setAttributeNS(null, 'y',
-          Math.round(node[prefix + 'y'] + fontSize / 3));
-
-        // Measures
-        // OPTIMIZE: Find a better way than a measurement canvas
-        x = Math.round(node[prefix + 'x'] - fontSize / 2 - 2);
-        y = Math.round(node[prefix + 'y'] - fontSize / 2 - 2);
-        w = Math.round(
-          measurementCanvas.measureText(node.label).width +
-            fontSize / 2 + size + 9
-        );
-        h = Math.round(fontSize + 4);
-        e = Math.round(fontSize / 2 + 2);
 
         // Circle
         circle.setAttributeNS(
-            null,
-            'class',
-            settings('classPrefix') + '-hover-area');
-        circle.setAttributeNS(null, 'fill', '#fff');
-        circle.setAttributeNS(null, 'cx', node[prefix + 'x']);
-        circle.setAttributeNS(null, 'cy', node[prefix + 'y']);
+          null,
+          'class',
+          settings('classPrefix') + '-hover-area');
+        circle.setAttributeNS(null, 'fill', '#f00');
+        circle.setAttributeNS(null, 'cx', x);
+        circle.setAttributeNS(null, 'cy', y);
         circle.setAttributeNS(null, 'r', e);
 
         // Rectangle
-        rectangle.setAttributeNS(
+        if (alignment !== 'center' &&
+            (alignment !== 'inside' || labelWidth > e * 2)) {
+          rectangle.setAttributeNS(
             null,
             'class',
             settings('classPrefix') + '-hover-area');
-        rectangle.setAttributeNS(null, 'fill', '#fff');
-        rectangle.setAttributeNS(null, 'x', node[prefix + 'x'] + e / 4);
-        rectangle.setAttributeNS(null, 'y', node[prefix + 'y'] - e);
-        rectangle.setAttributeNS(null, 'width', w);
-        rectangle.setAttributeNS(null, 'height', h);
+          rectangle.setAttributeNS(null, 'fill', '#f00');
+          rectangle.setAttributeNS(null, 'width', w);
+          rectangle.setAttributeNS(null, 'height', h);
+        } 
       }
 
       // Appending childs
       group.appendChild(circle);
       group.appendChild(rectangle);
-      group.appendChild(text);
       group.appendChild(nodeCircle);
+      group.appendChild(text);
 
       return group;
     }

--- a/src/renderers/svg/sigma.svg.hovers.def.js
+++ b/src/renderers/svg/sigma.svg.hovers.def.js
@@ -87,7 +87,7 @@
             text.setAttributeNS(null, 'x', x - labelWidth / 2);
             text.setAttributeNS(null, 'y', y - size - 2 * fontSize / 3);
             rectangle.setAttributeNS(null, 'x', x - w / 2);
-            rectangle.setAttributeNS(null, 'y', y - e);
+            rectangle.setAttributeNS(null, 'y', y - e - h);
             break;
           case 'bottom':
             text.setAttributeNS(null, 'x', x - labelWidth / 2);
@@ -128,22 +128,23 @@
           null,
           'class',
           settings('classPrefix') + '-hover-area');
-        circle.setAttributeNS(null, 'fill', '#f00');
+        circle.setAttributeNS(null, 'fill', '#fff');
         circle.setAttributeNS(null, 'cx', x);
         circle.setAttributeNS(null, 'cy', y);
         circle.setAttributeNS(null, 'r', e);
 
         // Rectangle
+        rectangle.setAttributeNS(
+          null,
+          'class',
+          settings('classPrefix') + '-hover-area');
+
         if (alignment !== 'center' &&
             (alignment !== 'inside' || labelWidth > e * 2)) {
-          rectangle.setAttributeNS(
-            null,
-            'class',
-            settings('classPrefix') + '-hover-area');
-          rectangle.setAttributeNS(null, 'fill', '#f00');
+          rectangle.setAttributeNS(null, 'fill', '#fff');
           rectangle.setAttributeNS(null, 'width', w);
           rectangle.setAttributeNS(null, 'height', h);
-        } 
+        }
       }
 
       // Appending childs

--- a/src/renderers/svg/sigma.svg.labels.def.js
+++ b/src/renderers/svg/sigma.svg.labels.def.js
@@ -46,13 +46,20 @@
     /**
      * SVG Element update.
      *
-     * @param  {object}                   node     The node object.
-     * @param  {DOMElement}               text     The label DOM element.
-     * @param  {configurable}             settings The settings function.
+     * @param  {object}             node                The node object.
+     * @param  {DOMElement}         text                The label DOM element.
+     * @param  {CanvasElement}      measurementCanvas   A fake canva handled by
+     *                              the svg to perform some measurements and
+     *                              passed by the renderer.
+     * @param  {configurable}       settings            The settings function.
      */
-    update: function(node, text, settings) {
+    update: function(node, text, measurementCanvas, settings) {
       var prefix = settings('prefix') || '',
-          size = node[prefix + 'size'];
+          size = node[prefix + 'size'],
+          alignment,
+          labelWidth = 0,
+          labelPlacementX,
+          labelPlacementY;
 
       var fontSize = (settings('labelSize') === 'fixed') ?
         settings('defaultLabelSize') :
@@ -65,11 +72,52 @@
       if (typeof node.label !== 'string')
         return;
 
+      if (settings('labelAlignment') === undefined) {
+        alignment = settings('defaultLabelAlignment');
+      } else {
+        alignment = settings('labelAlignment');
+      }
+
+      labelWidth = measurementCanvas.measureText(node.label).width;
+      labelPlacementX = Math.round(node[prefix + 'x'] + size + 3);
+      labelPlacementY = Math.round(node[prefix + 'y'] + fontSize / 3);
+
+      switch (alignment) {
+        case 'inside':
+          if (labelWidth >= (size + fontSize / 3) * 2) {
+            labelPlacementX = Math.round(node[prefix + 'x'] + size + 3);
+            break;
+          }
+        /* falls through*/
+        case 'center':
+          labelPlacementX = Math.round(node[prefix + 'x'] - labelWidth / 2);
+          break;
+        case 'left':
+          labelPlacementX =
+              Math.round(node[prefix + 'x'] - size - labelWidth - 3);
+          break;
+        case 'right':
+          labelPlacementX = Math.round(node[prefix + 'x'] + size + 3);
+          break;
+        case 'top':
+          labelPlacementX = Math.round(node[prefix + 'x'] - labelWidth / 2);
+          labelPlacementY = labelPlacementY - size - fontSize;
+          break;
+        case 'bottom':
+          labelPlacementX = Math.round(node[prefix + 'x'] - labelWidth / 2);
+          labelPlacementY = labelPlacementY + size + fontSize;
+          break;
+        default:
+          // Default is aligned 'right'
+          labelPlacementX = Math.round(node[prefix + 'x'] + size + 3);
+          break;
+      }
+
       // Updating
-      text.setAttributeNS(null, 'x',
-        Math.round(node[prefix + 'x'] + size + 3));
-      text.setAttributeNS(null, 'y',
-        Math.round(node[prefix + 'y'] + fontSize / 3));
+      text.setAttributeNS(null, 'x', labelPlacementX);
+      text.setAttributeNS(null, 'y', labelPlacementY);
+      text.innerHTML = node.label;
+      text.textContent = node.label;
 
       // Showing
       text.style.display = '';


### PR DESCRIPTION
- fix hover-area miscalculation due to CanvasRenderingContext2D not
  using the appropriate font size and font family
- add label alignment support for svg

There is an issue in Firefox that when you zoom in/out, the hovered areas don't get removed. This issue should be fixed by previous pending pull requests, https://github.com/jacomyal/sigma.js/pull/459 and https://github.com/jacomyal/sigma.js/pull/454