### PR TITLE
Update README.md fix grammar for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sigma is a JavaScript library dedicated to graph drawing, mainly developed by [@
 
 [The website](http://sigmajs.org) provides a global overview of the project, and the documentation is available in the [Github Wiki](https://github.com/jacomyal/sigma.js/wiki).
 
-Also, the `plugins` and `examples` directories contain some various use-cases that might help you understanding how to use sigma.
+Also, the `plugins` and `examples` directories contain various use-cases that might help you understand how to use sigma.
 
 ### How to use it
 


### PR DESCRIPTION
Fixed some grammar issues in README.md for better clarity. "Some" and "various" were redundant, and "help you understanding" was incorrect.

BEFORE: Also, the `plugins` and `examples` directories contain <b>some various</b> use-cases that might <b>help you understanding</b> how to use sigma.
AFTER: Also, the `plugins` and `examples` directories contain various use-cases that might help you understand how to use sigma.