### PR TITLE
Fixed two functions to reference their function parameters.

### DIFF
--- a/src/conrad.js
+++ b/src/conrad.js
@@ -697,14 +697,14 @@
   function _settings(v1, v2) {
     var o;
 
-    if (typeof a1 === 'string' && arguments.length === 1)
-      return _parameters[a1];
+    if (typeof v1 === 'string' && arguments.length === 1)
+      return _parameters[v1];
     else {
-      o = (typeof a1 === 'object' && arguments.length === 1) ?
-        a1 || {} :
+      o = (typeof v1 === 'object' && arguments.length === 1) ?
+        v1 || {} :
         {};
-      if (typeof a1 === 'string')
-        o[a1] = a2;
+      if (typeof v1 === 'string')
+        o[v1] = v2;
 
       for (var k in o)
         if (o[k] !== undefined)

--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -803,7 +803,7 @@
    * @param  {function(string): void} error     Callback for errors.
    * @return {WebGLProgram}                     The created program.
    */
-  sigma.utils.loadProgram = function(gl, shaders, attribs, loc, error) {
+  sigma.utils.loadProgram = function(gl, shaders, attribs, locations, error) {
     var i,
         linked,
         program = gl.createProgram();
@@ -816,7 +816,7 @@
         gl.bindAttribLocation(
           program,
           locations ? locations[i] : i,
-          opt_attribs[i]
+          attribs[i]
         );
 
     gl.linkProgram(program);


### PR DESCRIPTION
It looks like these two functions were referencing variables not defined in the function, by mistake. Noticed it when running sigma.js through the Closure Compiler. Let me know if anything looks amiss. 