### PR TITLE
fix _node mouseOver handling, repeated dragging

### DIFF
--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -143,6 +143,7 @@
         _node = _hoverStack[_hoverStack.length - 1];
       } else {
         _mouse.removeEventListener('mousedown', nodeMouseDown);
+        _node = null;
       }
     };
 
@@ -214,7 +215,6 @@
       });
       
       _drag = false;
-      _node = null;
     };
 
     function nodeMouseMove(event) {

--- a/src/misc/sigma.misc.bindEvents.js
+++ b/src/misc/sigma.misc.bindEvents.js
@@ -500,7 +500,6 @@
       captor.bind('mouseout', onOut);
       captor.bind('doubleclick', onDoubleClick);
       captor.bind('rightclick', onRightClick);
-      self.bind('render', onMove);
     }
 
     for (i = 0, l = this.captors.length; i < l; i++)


### PR DESCRIPTION
* `_node` should be `null`ed out as part of `treatNodeOut`, not `nodeMouseUp`; after a `mouseup`, the mouse is commonly still "over" `_node`.
* sending `render` events (which lack mouse-coordinate info) to `mouseMove` listeners was resulting in looking for the same cached coordinates in the quadtree every time, in `bindEvents`.

fixes #552 