### PR TITLE
Adds opacity attribute to nodes using canvas' global alpha value

### DIFF
--- a/src/renderers/canvas/sigma.canvas.nodes.def.js
+++ b/src/renderers/canvas/sigma.canvas.nodes.def.js
@@ -11,8 +11,10 @@
    * @param  {configurable}             settings The settings function.
    */
   sigma.canvas.nodes.def = function(node, context, settings) {
-    var prefix = settings('prefix') || '';
+    var prefix = settings('prefix') || '',
+        opac   = node.opacity || 1;
 
+    context.globalAlpha = opac;
     context.fillStyle = node.color || settings('defaultNodeColor');
     context.beginPath();
     context.arc(
@@ -26,5 +28,6 @@
 
     context.closePath();
     context.fill();
+    context.globalAlpha = 1;
   };
 })();


### PR DESCRIPTION
I found that instead of filtering nodes off of my graph completely, I just wanted to fade them so they were less significant. While edges support opacity through rgba, nodes don't. This addition simply leverages canvas' globalAlpha value while drawing the node so that you can specify opacity as a property of the node. 
