### PR TITLE
Replace Math.pow by litteral expressions when possible in utils.js

### DIFF
--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -255,8 +255,8 @@
   sigma.utils.getPointOnQuadraticCurve = function(t, x1, y1, x2, y2, xi, yi) {
     // http://stackoverflow.com/a/5634528
     return {
-      x: Math.pow(1 - t, 2) * x1 + 2 * (1 - t) * t * xi + Math.pow(t, 2) * x2,
-      y: Math.pow(1 - t, 2) * y1 + 2 * (1 - t) * t * yi + Math.pow(t, 2) * y2
+      x: (1 - t) * (1 - t) * x1 + 2 * (1 - t) * t * xi + t * t * x2,
+      y: (1 - t) * (1 - t) * y1 + 2 * (1 - t) * t * yi + t * t * y2
     };
   };
 
@@ -280,10 +280,10 @@
     function(t, x1, y1, x2, y2, cx, cy, dx, dy) {
     // http://stackoverflow.com/a/15397596
     // Blending functions:
-    var B0_t = Math.pow(1 - t, 3),
-        B1_t = 3 * t * Math.pow(1 - t, 2),
-        B2_t = 3 * Math.pow(t, 2) * (1 - t),
-        B3_t = Math.pow(t, 3);
+    var B0_t = (1 - t) * (1 - t) * (1 - t),
+        B1_t = 3 * t * (1 - t) * (1 - t),
+        B2_t = 3 * t * t * (1 - t),
+        B3_t = t * t * t;
 
     return {
       x: (B0_t * x1) + (B1_t * cx) + (B2_t * dx) + (B3_t * x2),
@@ -321,7 +321,7 @@
    * @return {number}     The euclidian distance.
    */
   sigma.utils.getDistance = function(x0, y0, x1, y1) {
-    return Math.sqrt(Math.pow(x1 - x0, 2) + Math.pow(y1 - y0, 2));
+    return Math.sqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
   };
 
   /**


### PR DESCRIPTION
Math.pow is significantly slower in IE11 according to https://jsperf.com/math-pow-vs-simple-multiplication.

This PR replaces `Math.pow(x,2)` by `x*x` and `Math.pow(x,3)` by `x*x*x`.