### PR TITLE
Fix/misc pow

### DIFF
--- a/src/captors/sigma.captors.touch.js
+++ b/src/captors/sigma.captors.touch.js
@@ -156,8 +156,8 @@
               _startTouchX1 - _startTouchX0
             );
             _startTouchDistance = Math.sqrt(
-              Math.pow(_startTouchY1 - _startTouchY0, 2) +
-              Math.pow(_startTouchX1 - _startTouchX0, 2)
+              (_startTouchY1 - _startTouchY0) * (_startTouchY1 - _startTouchY0) +
+              (_startTouchX1 - _startTouchX0) * (_startTouchX1 - _startTouchX0)
             );
 
             e.preventDefault();
@@ -318,7 +318,7 @@
 
             dAngle = Math.atan2(y1 - y0, x1 - x0) - _startTouchAngle;
             dRatio = Math.sqrt(
-              Math.pow(y1 - y0, 2) + Math.pow(x1 - x0, 2)
+              (y1 - y0) * (y1 - y0) + (x1 - x0) * (x1 - x0)
             ) / _startTouchDistance;
 
             // Translation:

--- a/src/classes/sigma.classes.edgequad.js
+++ b/src/classes/sigma.classes.edgequad.js
@@ -211,8 +211,8 @@
     lowerLeftCoor: function(r) {
       var width = (
         Math.sqrt(
-          Math.pow(r.x2 - r.x1, 2) +
-          Math.pow(r.y2 - r.y1, 2)
+          (r.x2 - r.x1) * (r.x2 - r.x1) +
+          (r.y2 - r.y1) * (r.y2 - r.y1)
         )
       );
 
@@ -318,7 +318,7 @@
     projection: function(c, a) {
       var l = (
         (c.x * a.x + c.y * a.y) /
-        (Math.pow(a.x, 2) + Math.pow(a.y, 2))
+        (a.x * a.x + a.y * a.y)
       );
 
       return {

--- a/src/classes/sigma.classes.quad.js
+++ b/src/classes/sigma.classes.quad.js
@@ -96,8 +96,8 @@
     lowerLeftCoor: function(r) {
       var width = (
         Math.sqrt(
-          Math.pow(r.x2 - r.x1, 2) +
-          Math.pow(r.y2 - r.y1, 2)
+          (r.x2 - r.x1) * (r.x2 - r.x1) +
+          (r.y2 - r.y1) * (r.y2 - r.y1)
         )
       );
 
@@ -203,7 +203,7 @@
     projection: function(c, a) {
       var l = (
         (c.x * a.x + c.y * a.y) /
-        (Math.pow(a.x, 2) + Math.pow(a.y, 2))
+        (a.x * a.x + a.y * a.y)
       );
 
       return {

--- a/src/misc/sigma.misc.bindEvents.js
+++ b/src/misc/sigma.misc.bindEvents.js
@@ -62,8 +62,8 @@
             modifiedY > y - s &&
             modifiedY < y + s &&
             Math.sqrt(
-              Math.pow(modifiedX - x, 2) +
-              Math.pow(modifiedY - y, 2)
+              (modifiedX - x) * (modifiedX - x) +
+              (modifiedY - y) * (modifiedY - y)
             ) < s
           ) {
             // Insert the node:

--- a/src/renderers/canvas/sigma.canvas.edgehovers.arrow.js
+++ b/src/renderers/canvas/sigma.canvas.edgehovers.arrow.js
@@ -29,7 +29,7 @@
     size = (edge.hover) ?
       settings('edgeHoverSizeRatio') * size : size;
     var aSize = size * 2.5,
-        d = Math.sqrt(Math.pow(tX - sX, 2) + Math.pow(tY - sY, 2)),
+        d = Math.sqrt((tX - sX) * (tX - sX) + (tY - sY) * (tY - sY)),
         aX = sX + (tX - sX) * (d - aSize - tSize) / d,
         aY = sY + (tY - sY) * (d - aSize - tSize) / d,
         vX = (tX - sX) * aSize / d,

--- a/src/renderers/canvas/sigma.canvas.edgehovers.curvedArrow.js
+++ b/src/renderers/canvas/sigma.canvas.edgehovers.curvedArrow.js
@@ -38,7 +38,7 @@
       sigma.utils.getQuadraticControlPoint(sX, sY, tX, tY);
 
     if (source.id === target.id) {
-      d = Math.sqrt(Math.pow(tX - cp.x1, 2) + Math.pow(tY - cp.y1, 2));
+      d = Math.sqrt((tX - cp.x1) * (tX - cp.x1) + (tY - cp.y1) * (tY - cp.y1));
       aSize = size * 2.5;
       aX = cp.x1 + (tX - cp.x1) * (d - aSize - tSize) / d;
       aY = cp.y1 + (tY - cp.y1) * (d - aSize - tSize) / d;
@@ -46,7 +46,7 @@
       vY = (tY - cp.y1) * aSize / d;
     }
     else {
-      d = Math.sqrt(Math.pow(tX - cp.x, 2) + Math.pow(tY - cp.y, 2));
+      d = Math.sqrt((tX - cp.x) * (tX - cp.x) + (tY - cp.y) * (tY - cp.y));
       aSize = size * 2.5;
       aX = cp.x + (tX - cp.x) * (d - aSize - tSize) / d;
       aY = cp.y + (tY - cp.y) * (d - aSize - tSize) / d;

--- a/src/renderers/canvas/sigma.canvas.edges.arrow.js
+++ b/src/renderers/canvas/sigma.canvas.edges.arrow.js
@@ -25,7 +25,7 @@
         tX = target[prefix + 'x'],
         tY = target[prefix + 'y'],
         aSize = Math.max(size * 2.5, settings('minArrowSize')),
-        d = Math.sqrt(Math.pow(tX - sX, 2) + Math.pow(tY - sY, 2)),
+        d = Math.sqrt((tX - sX) * (tX - sX) + (tY - sY) * (tY - sY)),
         aX = sX + (tX - sX) * (d - aSize - tSize) / d,
         aY = sY + (tY - sY) * (d - aSize - tSize) / d,
         vX = (tX - sX) * aSize / d,

--- a/src/renderers/canvas/sigma.canvas.edges.curvedArrow.js
+++ b/src/renderers/canvas/sigma.canvas.edges.curvedArrow.js
@@ -38,14 +38,14 @@
       sigma.utils.getQuadraticControlPoint(sX, sY, tX, tY);
 
     if (source.id === target.id) {
-      d = Math.sqrt(Math.pow(tX - cp.x1, 2) + Math.pow(tY - cp.y1, 2));
+      d = Math.sqrt((tX - cp.x1) * (tX - cp.x1) + (tY - cp.y1) * (tY - cp.y1));
       aX = cp.x1 + (tX - cp.x1) * (d - aSize - tSize) / d;
       aY = cp.y1 + (tY - cp.y1) * (d - aSize - tSize) / d;
       vX = (tX - cp.x1) * aSize / d;
       vY = (tY - cp.y1) * aSize / d;
     }
     else {
-      d = Math.sqrt(Math.pow(tX - cp.x, 2) + Math.pow(tY - cp.y, 2));
+      d = Math.sqrt((tX - cp.x) * (tX - cp.x) + (tY - cp.y) * (tY - cp.y));
       aX = cp.x + (tX - cp.x) * (d - aSize - tSize) / d;
       aY = cp.y + (tY - cp.y) * (d - aSize - tSize) / d;
       vX = (tX - cp.x) * aSize / d;

--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -255,8 +255,8 @@
   sigma.utils.getPointOnQuadraticCurve = function(t, x1, y1, x2, y2, xi, yi) {
     // http://stackoverflow.com/a/5634528
     return {
-      x: Math.pow(1 - t, 2) * x1 + 2 * (1 - t) * t * xi + Math.pow(t, 2) * x2,
-      y: Math.pow(1 - t, 2) * y1 + 2 * (1 - t) * t * yi + Math.pow(t, 2) * y2
+      x: (1 - t) * (1 - t) * x1 + 2 * (1 - t) * t * xi + t * t * x2,
+      y: (1 - t) * (1 - t) * y1 + 2 * (1 - t) * t * yi + t * t * y2
     };
   };
 
@@ -280,10 +280,10 @@
     function(t, x1, y1, x2, y2, cx, cy, dx, dy) {
     // http://stackoverflow.com/a/15397596
     // Blending functions:
-    var B0_t = Math.pow(1 - t, 3),
-        B1_t = 3 * t * Math.pow(1 - t, 2),
-        B2_t = 3 * Math.pow(t, 2) * (1 - t),
-        B3_t = Math.pow(t, 3);
+    var B0_t = (1 - t) * (1 - t) * (1 - t),
+        B1_t = 3 * t * (1 - t) * (1 - t),
+        B2_t = 3 * t * t * (1 - t),
+        B3_t = t * t * t;
 
     return {
       x: (B0_t * x1) + (B1_t * cx) + (B2_t * dx) + (B3_t * x2),
@@ -321,7 +321,7 @@
    * @return {number}     The euclidian distance.
    */
   sigma.utils.getDistance = function(x0, y0, x1, y1) {
-    return Math.sqrt(Math.pow(x1 - x0, 2) + Math.pow(y1 - y0, 2));
+    return Math.sqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
   };
 
   /**


### PR DESCRIPTION
Replace Math.pow by litteral expressions when possible.

Math.pow is significantly slower in IE11 according to https://jsperf.com/math-pow-vs-simple-multiplication.

This PR replaces Math.pow(x,2) by x*x and Math.pow(x,3) by x*x*x.