### PR TITLE
Add maxLevel of quadtrees to Sigma settings

### DIFF
--- a/src/sigma.core.js
+++ b/src/sigma.core.js
@@ -531,6 +531,7 @@
         // Refresh quadtree:
         c.quadtree.index(this.graph.nodes(), {
           prefix: c.readPrefix,
+          maxLevel: c.settings('nodeQuadtreeMaxLevel'),
           bounds: {
             x: bounds.minX,
             y: bounds.minY,
@@ -547,6 +548,7 @@
         ) {
           c.edgequadtree.index(this.graph, {
             prefix: c.readPrefix,
+            maxLevel: c.settings('edgeQuadtreeMaxLevel'),
             bounds: {
               x: bounds.minX,
               y: bounds.minY,

--- a/src/sigma.settings.js
+++ b/src/sigma.settings.js
@@ -223,6 +223,16 @@
 
 
 
+    /**
+     * SPATIAL INDEXING SETTINGS:
+     * ****************
+     */
+    // {number} Max height of the node quad tree.
+    nodeQuadtreeMaxLevel: 4,
+    // {number} Max height of the edge quad tree.
+    edgeQuadtreeMaxLevel: 4,
+
+
 
     /**
      * CAMERA SETTINGS:


### PR DESCRIPTION
The maxLevel parameter of quad trees has a strong impact on indexing speed, and their optimization depends on the graph topology and layout, so we should make it configurable.