### PR TITLE
#152 add beforeRender event

### DIFF
--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -114,6 +114,8 @@
   sigma.renderers.canvas.prototype.render = function(options) {
     options = options || {};
 
+    this.dispatchEvent('beforeRender');
+
     var a,
         i,
         k,

--- a/src/renderers/sigma.renderers.svg.js
+++ b/src/renderers/sigma.renderers.svg.js
@@ -33,6 +33,8 @@
         fn,
         self = this;
 
+    this.dispatchEvent('beforeRender');
+
     sigma.classes.dispatcher.extend(this);
 
     // Initialize main attributes:

--- a/src/renderers/sigma.renderers.webgl.js
+++ b/src/renderers/sigma.renderers.webgl.js
@@ -31,6 +31,8 @@
         fn,
         _self = this;
 
+    this.dispatchEvent('beforeRender');
+
     sigma.classes.dispatcher.extend(this);
 
     // Conrad related attributes:


### PR DESCRIPTION
Trigger a `beforeRender` event for each renderer. Because the events are synchrones, it acts like a hook.

I can be useful in many cases:

* tuning the settings for each render (disabling a plugin while moving the camera for example)
* timing a renderer (to display a FPS counter for each renderer for example)
