### PR TITLE
Fix #159: Add renderers smoke tests

### DIFF
--- a/test/unit.html
+++ b/test/unit.html
@@ -4,39 +4,59 @@
   <meta charset="utf-8">
   <title>sigma.js | unit tests</title>
   <link rel="stylesheet" href="qunit/qunit.css">
-  <script src="../src/sigma.core.js"></script>
-  <script src="../src/conrad.js"></script>
-  <script src="../src/utils/sigma.utils.js"></script>
-  <script src="../src/utils/sigma.polyfills.js"></script>
-  <script src="../src/sigma.settings.js"></script>
-  <script src="../src/classes/sigma.classes.dispatcher.js"></script>
-  <script src="../src/classes/sigma.classes.configurable.js"></script>
-  <script src="../src/classes/sigma.classes.graph.js"></script>
-  <script src="../src/classes/sigma.classes.camera.js"></script>
-  <script src="../src/classes/sigma.classes.quad.js"></script>
-  <script src="../src/classes/sigma.classes.edgequad.js"></script>
-  <script src="../src/captors/sigma.captors.mouse.js"></script>
-  <script src="../src/captors/sigma.captors.touch.js"></script>
-  <script src="../src/renderers/sigma.renderers.canvas.js"></script>
-  <script src="../src/renderers/sigma.renderers.webgl.js"></script>
-  <script src="../src/renderers/sigma.renderers.def.js"></script>
-  <script src="../src/renderers/webgl/sigma.webgl.nodes.def.js"></script>
-  <script src="../src/renderers/webgl/sigma.webgl.nodes.fast.js"></script>
-  <script src="../src/renderers/webgl/sigma.webgl.edges.def.js"></script>
-  <script src="../src/renderers/webgl/sigma.webgl.edges.fast.js"></script>
-  <script src="../src/renderers/canvas/sigma.canvas.labels.def.js"></script>
-  <script src="../src/renderers/canvas/sigma.canvas.hovers.def.js"></script>
-  <script src="../src/renderers/canvas/sigma.canvas.nodes.def.js"></script>
-  <script src="../src/renderers/canvas/sigma.canvas.edges.def.js"></script>
-  <script src="../src/middlewares/sigma.middlewares.rescale.js"></script>
-  <script src="../src/middlewares/sigma.middlewares.copy.js"></script>
-  <script src="../src/misc/sigma.misc.animation.js"></script>
-  <script src="../src/misc/sigma.misc.bindEvents.js"></script>
-  <script src="../src/misc/sigma.misc.drawHovers.js"></script>
-  <script src="../plugins/sigma.plugins.filter/sigma.plugins.filter.js"></script>
-  <script src="../plugins/sigma.statistics.HITS/sigma.statistics.HITS.js"></script>
+<!-- START SIGMA IMPORTS -->
+<script src="../src/sigma.core.js"></script>
+<script src="../src/conrad.js"></script>
+<script src="../src/utils/sigma.utils.js"></script>
+<script src="../src/utils/sigma.polyfills.js"></script>
+<script src="../src/sigma.settings.js"></script>
+<script src="../src/classes/sigma.classes.dispatcher.js"></script>
+<script src="../src/classes/sigma.classes.configurable.js"></script>
+<script src="../src/classes/sigma.classes.graph.js"></script>
+<script src="../src/classes/sigma.classes.camera.js"></script>
+<script src="../src/classes/sigma.classes.quad.js"></script>
+<script src="../src/classes/sigma.classes.edgequad.js"></script>
+<script src="../src/captors/sigma.captors.mouse.js"></script>
+<script src="../src/captors/sigma.captors.touch.js"></script>
+<script src="../src/renderers/sigma.renderers.canvas.js"></script>
+<script src="../src/renderers/sigma.renderers.webgl.js"></script>
+<script src="../src/renderers/sigma.renderers.svg.js"></script>
+<script src="../src/renderers/sigma.renderers.def.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.nodes.def.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.nodes.fast.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.edges.def.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.edges.fast.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.edges.arrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.labels.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.hovers.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.nodes.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edges.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edges.curve.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edges.arrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edges.curvedArrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edgehovers.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edgehovers.curve.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edgehovers.arrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edgehovers.curvedArrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.extremities.def.js"></script>
+<script src="../src/renderers/svg/sigma.svg.utils.js"></script>
+<script src="../src/renderers/svg/sigma.svg.nodes.def.js"></script>
+<script src="../src/renderers/svg/sigma.svg.edges.def.js"></script>
+<script src="../src/renderers/svg/sigma.svg.edges.curve.js"></script>
+<script src="../src/renderers/svg/sigma.svg.labels.def.js"></script>
+<script src="../src/renderers/svg/sigma.svg.hovers.def.js"></script>
+<script src="../src/middlewares/sigma.middlewares.rescale.js"></script>
+<script src="../src/middlewares/sigma.middlewares.copy.js"></script>
+<script src="../src/misc/sigma.misc.animation.js"></script>
+<script src="../src/misc/sigma.misc.bindEvents.js"></script>
+<script src="../src/misc/sigma.misc.bindDOMEvents.js"></script>
+<script src="../src/misc/sigma.misc.drawHovers.js"></script>
+<!-- END SIGMA IMPORTS -->
+<script src="../plugins/sigma.plugins.filter/sigma.plugins.filter.js"></script>
+<script src="../plugins/sigma.statistics.HITS/sigma.statistics.HITS.js"></script>
 </head>
 <body>
+  <div style="height: 200px;display: none;" id="graph-container"></div>
   <div id="qunit"></div>
   <script src="qunit/qunit.js"></script>
   <script src="unit.dispatcher.js"></script>
@@ -49,5 +69,6 @@
   <script src="unit.core.js"></script>
   <script src="unit.plugins.filter.js"></script>
   <script src="unit.HITS.js"></script>
+  <script src="unit.renderers.js"></script>
 </body>
 </html>

--- a/test/unit.renderers.js
+++ b/test/unit.renderers.js
@@ -1,0 +1,69 @@
+module('sigma.renderers');
+
+test('Renderers Smoke Test', function() {
+  var container = document.getElementById('graph-container');
+
+  var renderers = ['svg','canvas'];
+
+  // Check if WebGL is enabled:
+  var canvas, webgl = !!window.WebGLRenderingContext;
+  if (webgl) {
+    canvas = document.createElement('canvas');
+    try {
+      webgl = !!(
+        canvas.getContext('webgl') ||
+        canvas.getContext('experimental-webgl')
+      );
+    } catch (e) {
+      webgl = false;
+    }
+  }
+  if(webgl){
+    renderers.push('webgl');
+  }
+
+  renderers.forEach(function(renderer){
+    var i,
+        N = 100,
+        E = 500,
+        s = new sigma(),
+        cam = s.addCamera();
+
+    // Generate a random graph:
+    for (i = 0; i < N; i++)
+      s.graph.addNode({
+        id: 'n' + i,
+        label: 'Node ' + i,
+        x: Math.random(),
+        y: Math.random(),
+        size: 4 + (3 * Math.random()) | 0
+      });
+
+    for (i = 0; i < E; i++)
+      s.graph.addEdge({
+        id: 'e' + i,
+        source: 'n' + (Math.random() * N | 0),
+        target: 'n' + (Math.random() * N | 0),
+        size: 1 + Math.random()
+      });
+
+
+    s.addRenderer({
+      container: document.getElementById('graph-container'),
+      type: renderer,
+      camera: cam,
+      settings: {
+        defaultLabelColor: '#000',
+        defaultNodeColor: '#666',
+        defaultEdgeColor: '#999',
+        edgeColor: 'default'
+      }
+    });
+
+    s.refresh();
+
+    ok(true, renderer+" renderer working");
+
+    container.innerHTML = "";
+  })
+});


### PR DESCRIPTION
Add some smoke testing to the renderers. 

For WebGL, you have to open a webgl-compatible browser for now. I'm gonna try to automate this via BrowserStack