### PR TITLE
#169 add pre/post hooks for the canvas renderers

### DIFF
--- a/src/misc/sigma.misc.drawHovers.js
+++ b/src/misc/sigma.misc.drawHovers.js
@@ -54,165 +54,62 @@
       // Clear self.contexts.hover:
       self.contexts.hover.canvas.width = self.contexts.hover.canvas.width;
 
-      var k,
-          source,
-          target,
-          hoveredNode,
-          hoveredEdge,
+      var hoveredNodesArr = Object.keys(hoveredNodes).map(function(key){
+                return hoveredNodes[key];
+          }),
+          hoveredEdgesArr = Object.keys(hoveredEdges).map(function(key){
+                return hoveredEdges[key];
+          }),
           defaultNodeType = self.settings('defaultNodeType'),
           defaultEdgeType = self.settings('defaultEdgeType'),
-          nodeRenderers = sigma.canvas.hovers,
-          edgeRenderers = sigma.canvas.edgehovers,
-          extremitiesRenderers = sigma.canvas.extremities,
           embedSettings = self.settings.embedObjects({
             prefix: prefix
+          }),
+          end = embedSettings('singleHover') ? 1 : undefined;
+
+      // Node render
+      if (embedSettings('enableHovering') && hoveredNodesArr.length > 0){
+        sigma.renderers.canvas.applyRenderers({
+          elements: hoveredNodesArr,
+          renderers: sigma.canvas.hovers,
+          type: 'nodes',
+          ctx: self.contexts.hover,
+          end: end,
+          settings: embedSettings,
+        });
+      }
+
+      // Edge render
+      if (embedSettings('enableEdgeHovering') && hoveredEdgesArr.length > 0) {
+        sigma.renderers.canvas.applyRenderers({
+          elements: hoveredEdgesArr,
+          renderers: sigma.canvas.edgehovers,
+          type: 'edges',
+          ctx: self.contexts.hover,
+          end: end,
+          settings: embedSettings,
+          graph: self.graph,
+        });
+
+        if (embedSettings('edgeHoverExtremities')) {
+          sigma.renderers.canvas.applyRenderers({
+            elements: hoveredEdgesArr,
+            renderers: sigma.canvas.extremities,
+            type: 'edges',
+            ctx: self.contexts.hover,
+            end: end,
+            settings: embedSettings,
+            graph: self.graph,
           });
-
-      // Node render: single hover
-      if (
-        embedSettings('enableHovering') &&
-        embedSettings('singleHover') &&
-        Object.keys(hoveredNodes).length
-      ) {
-        hoveredNode = hoveredNodes[Object.keys(hoveredNodes)[0]];
-        (
-          nodeRenderers[hoveredNode.type] ||
-          nodeRenderers[defaultNodeType] ||
-          nodeRenderers.def
-        )(
-          hoveredNode,
-          self.contexts.hover,
-          embedSettings
-        );
-      }
-
-      // Node render: multiple hover
-      if (
-        embedSettings('enableHovering') &&
-        !embedSettings('singleHover')
-      )
-        for (k in hoveredNodes)
-          (
-            nodeRenderers[hoveredNodes[k].type] ||
-            nodeRenderers[defaultNodeType] ||
-            nodeRenderers.def
-          )(
-            hoveredNodes[k],
-            self.contexts.hover,
-            embedSettings
-          );
-
-      // Edge render: single hover
-      if (
-        embedSettings('enableEdgeHovering') &&
-        embedSettings('singleHover') &&
-        Object.keys(hoveredEdges).length
-      ) {
-        hoveredEdge = hoveredEdges[Object.keys(hoveredEdges)[0]];
-        source = self.graph.nodes(hoveredEdge.source);
-        target = self.graph.nodes(hoveredEdge.target);
-
-        if (! hoveredEdge.hidden) {
-          (
-            edgeRenderers[hoveredEdge.type] ||
-            edgeRenderers[defaultEdgeType] ||
-            edgeRenderers.def
-          ) (
-            hoveredEdge,
-            source,
-            target,
-            self.contexts.hover,
-            embedSettings
-          );
-
-          if (embedSettings('edgeHoverExtremities')) {
-            (
-              extremitiesRenderers[hoveredEdge.type] ||
-              extremitiesRenderers.def
-            )(
-              hoveredEdge,
-              source,
-              target,
-              self.contexts.hover,
-              embedSettings
-            );
-
-          } else {
-            // Avoid edges rendered over nodes:
-            (
-              sigma.canvas.nodes[source.type] ||
-              sigma.canvas.nodes.def
-            ) (
-              source,
-              self.contexts.hover,
-              embedSettings
-            );
-            (
-              sigma.canvas.nodes[target.type] ||
-              sigma.canvas.nodes.def
-            ) (
-              target,
-              self.contexts.hover,
-              embedSettings
-            );
-          }
-        }
-      }
-
-      // Edge render: multiple hover
-      if (
-        embedSettings('enableEdgeHovering') &&
-        !embedSettings('singleHover')
-      ) {
-        for (k in hoveredEdges) {
-          hoveredEdge = hoveredEdges[k];
-          source = self.graph.nodes(hoveredEdge.source);
-          target = self.graph.nodes(hoveredEdge.target);
-
-          if (!hoveredEdge.hidden) {
-            (
-              edgeRenderers[hoveredEdge.type] ||
-              edgeRenderers[defaultEdgeType] ||
-              edgeRenderers.def
-            ) (
-              hoveredEdge,
-              source,
-              target,
-              self.contexts.hover,
-              embedSettings
-            );
-
-            if (embedSettings('edgeHoverExtremities')) {
-              (
-                extremitiesRenderers[hoveredEdge.type] ||
-                extremitiesRenderers.def
-              )(
-                hoveredEdge,
-                source,
-                target,
-                self.contexts.hover,
-                embedSettings
-              );
-            } else {
-              // Avoid edges rendered over nodes:
-              (
-                sigma.canvas.nodes[source.type] ||
-                sigma.canvas.nodes.def
-              ) (
-                source,
-                self.contexts.hover,
-                embedSettings
-              );
-              (
-                sigma.canvas.nodes[target.type] ||
-                sigma.canvas.nodes.def
-              ) (
-                target,
-                self.contexts.hover,
-                embedSettings
-              );
-            }
-          }
+        } else { //draw nodes over edges
+          sigma.renderers.canvas.applyRenderers({
+            elements: hoveredNodes,
+            renderers: sigma.canvas.nodes,
+            type: 'nodes',
+            ctx: self.contexts.nodes,
+            end: end,
+            settings: embedSettings,
+          });
         }
       }
     }

--- a/src/misc/sigma.misc.drawHovers.js
+++ b/src/misc/sigma.misc.drawHovers.js
@@ -87,7 +87,7 @@
         sigma.renderers.canvas.applyRenderers(renderParams);
 
         if (embedSettings('edgeHoverExtremities')) {
-          renderParams.renderers = sigma.canvas.edgehovers;
+          renderParams.renderers = sigma.canvas.extremities;
           sigma.renderers.canvas.applyRenderers(renderParams);
         } else { //draw nodes over edges
           renderParams.ctx = self.contexts.nodes;

--- a/src/misc/sigma.misc.drawHovers.js
+++ b/src/misc/sigma.misc.drawHovers.js
@@ -54,62 +54,47 @@
       // Clear self.contexts.hover:
       self.contexts.hover.canvas.width = self.contexts.hover.canvas.width;
 
-      var hoveredNodesArr = Object.keys(hoveredNodes).map(function(key){
+      var hoveredNodesArr = Object.keys(hoveredNodes).map(function(key) {
                 return hoveredNodes[key];
           }),
-          hoveredEdgesArr = Object.keys(hoveredEdges).map(function(key){
+          hoveredEdgesArr = Object.keys(hoveredEdges).map(function(key) {
                 return hoveredEdges[key];
           }),
-          defaultNodeType = self.settings('defaultNodeType'),
-          defaultEdgeType = self.settings('defaultEdgeType'),
           embedSettings = self.settings.embedObjects({
             prefix: prefix
           }),
-          end = embedSettings('singleHover') ? 1 : undefined;
+          end = embedSettings('singleHover') ? 1 : undefined,
+          renderParams = {
+            elements: hoveredNodesArr,
+            renderers: sigma.canvas.hovers,
+            type: 'nodes',
+            ctx: self.contexts.hover,
+            end: end,
+            graph: self.graph,
+            settings: embedSettings,
+          };
 
       // Node render
-      if (embedSettings('enableHovering') && hoveredNodesArr.length > 0){
-        sigma.renderers.canvas.applyRenderers({
-          elements: hoveredNodesArr,
-          renderers: sigma.canvas.hovers,
-          type: 'nodes',
-          ctx: self.contexts.hover,
-          end: end,
-          settings: embedSettings,
-        });
+      if (embedSettings('enableHovering')) {
+        sigma.renderers.canvas.applyRenderers(renderParams);
       }
 
       // Edge render
-      if (embedSettings('enableEdgeHovering') && hoveredEdgesArr.length > 0) {
-        sigma.renderers.canvas.applyRenderers({
-          elements: hoveredEdgesArr,
-          renderers: sigma.canvas.edgehovers,
-          type: 'edges',
-          ctx: self.contexts.hover,
-          end: end,
-          settings: embedSettings,
-          graph: self.graph,
-        });
+      if (embedSettings('enableEdgeHovering')) {
+        renderParams.renderers = sigma.canvas.edgehovers;
+        renderParams.elements = hoveredEdgesArr;
+        renderParams.type = 'edges';
+        sigma.renderers.canvas.applyRenderers(renderParams);
 
         if (embedSettings('edgeHoverExtremities')) {
-          sigma.renderers.canvas.applyRenderers({
-            elements: hoveredEdgesArr,
-            renderers: sigma.canvas.extremities,
-            type: 'edges',
-            ctx: self.contexts.hover,
-            end: end,
-            settings: embedSettings,
-            graph: self.graph,
-          });
+          renderParams.renderers = sigma.canvas.edgehovers;
+          sigma.renderers.canvas.applyRenderers(renderParams);
         } else { //draw nodes over edges
-          sigma.renderers.canvas.applyRenderers({
-            elements: hoveredNodes,
-            renderers: sigma.canvas.nodes,
-            type: 'nodes',
-            ctx: self.contexts.nodes,
-            end: end,
-            settings: embedSettings,
-          });
+          renderParams.ctx = self.contexts.nodes;
+          renderParams.type = 'nodes';
+          renderParams.renderers = sigma.canvas.nodes;
+          renderParams.elements = hoveredNodes;
+          sigma.renderers.canvas.applyRenderers(renderParams);
         }
       }
     }

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -105,16 +105,19 @@
 
   /**
    * Render elements with the given renderers
-   * 
-   * @param  {array}                 renderers  Renderers to use
-   * @param  {string}                type       "edges" or "nodes"
-   * @param  {array}                 elements   Elements to render
-   * @param  {Context2D}             ctx        Ctontext to draz on
-   * @param  {integer}               start      Starting index of the elements to render
-   * @param  {integer}               end        Last index of the elements to render
-   * @param  {object}                options    An object of options.
+   *
+   * @param  {array}        renderers  Renderers to use
+   * @param  {string}       type       "edges" or "nodes"
+   * @param  {array}        elements   Elements to render
+   * @param  {Context2D}    ctx        Ctontext to draz on
+   * @param  {integer}      start      Starting index of
+   *                                   the elements to render
+   * @param  {integer}      end        Last index of
+   *                                   the elements to render
+   * @param  {object}       options    An object of options.
    */
-  sigma.renderers.canvas.prototype.renderRenderers = function(renderers, type, elements, ctx, start, end, options) {
+  sigma.renderers.canvas.prototype.renderRenderers = function(renderers, type,
+    elements, ctx, start, end, options) {
     var a,
         i,
         renderer,
@@ -126,19 +129,19 @@
           prefix: this.options.prefix
         });
 
-    for(renderer in renderers){
-      if(renderers[renderer].pre){
+    for (renderer in renderers) {
+      if (renderers[renderer].pre) {
         renderers[renderer].pre(ctx, embedSettings);
       }
     }
-    for (a = elements, i = start; i < end; i++){
-      if (!a[i].hidden){
+    for (a = elements, i = start; i < end; i++) {
+      if (!a[i].hidden) {
         specialized_renderer = renderers[
           a[i].type || this.settings(options, type)
-        ]
+        ];
         def = (specialized_renderer || renderers.def);
         render = (def.render || def);
-        if(type == 'edges'){
+        if (type == 'edges') {
           render(
             a[i],
             this.graph.nodes(a[i].source),
@@ -146,7 +149,7 @@
             ctx,
             embedSettings
           );
-        }else{
+        }else {
           render(
             a[i],
             ctx,
@@ -155,8 +158,8 @@
         }
       }
     }
-    for(renderer in renderers){
-      if(renderers[renderer].post){
+    for (renderer in renderers) {
+      if (renderers[renderer].post) {
         renderers[renderer].post(ctx, embedSettings);
       }
     }
@@ -165,8 +168,9 @@
 
   /**
    * Render a batch of edges
-   * 
-   * @param    {integer}               start   Starting index of the edges to render
+   *
+   * @param    {integer}               start   Starting index of the edges
+   *                                           to render
    * @param    {integer}               end     An object of options.
    * @param    {object}                options An object of options.
    */
@@ -174,8 +178,8 @@
     this.renderRenderers(sigma.canvas.edges, 'edges', this.edgesOnScreen,
         this.contexts.edges, start, end, options);
     if (this.settings(options, 'drawEdgeLabels')) {
-      this.renderRenderers(sigma.canvas.edges.labels, 'edges', this.edgesOnScreen,
-           this.contexts.labels, start, end, options);
+      this.renderRenderers(sigma.canvas.edges.labels, 'edges',
+        this.edgesOnScreen, this.contexts.labels, start, end, options);
     }
   };
 
@@ -278,7 +282,7 @@
           tempGCO = this.contexts.edges.globalCompositeOperation;
           this.contexts.edges.globalCompositeOperation = 'destination-over';
 
-          this.renderEdges(start,end, options);
+          this.renderEdges(start, end, options);
 
           // Restore original globalCompositeOperation:
           this.contexts.edges.globalCompositeOperation = tempGCO;
@@ -307,14 +311,14 @@
     // - No batching
     if (drawNodes) {
       this.renderRenderers(sigma.canvas.nodes, 'nodes', this.nodesOnScreen,
-        this.contexts.nodes, 0,  this.nodesOnScreen.length, options);
+        this.contexts.nodes, 0, this.nodesOnScreen.length, options);
     }
 
     // Draw labels:
     // - No batching
     if (drawLabels) {
       this.renderRenderers(sigma.canvas.labels, 'nodes', this.nodesOnScreen,
-        this.contexts.labels, 0,  this.nodesOnScreen.length, options);
+        this.contexts.labels, 0, this.nodesOnScreen.length, options);
     }
 
     this.dispatchEvent('render');

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -104,19 +104,19 @@
 
 
   /**
-   * Render elements with the given renderers
+   * Render edges or nodes with the given renderers
    *
    * @param  {array}        renderers  Renderers to use
    * @param  {string}       type       "edges" or "nodes"
    * @param  {array}        elements   Elements to render
-   * @param  {Context2D}    ctx        Ctontext to draz on
+   * @param  {Context2D}    ctx        Context to draw on
    * @param  {integer}      start      Starting index of
    *                                   the elements to render
    * @param  {integer}      end        Last index of
    *                                   the elements to render
    * @param  {object}       options    An object of options.
    */
-  sigma.renderers.canvas.prototype.renderRenderers = function(renderers, type,
+  sigma.renderers.canvas.prototype.applyRenderers = function(renderers, type,
     elements, ctx, start, end, options) {
     var a,
         i,
@@ -175,10 +175,10 @@
    * @param    {object}                options An object of options.
    */
   sigma.renderers.canvas.prototype.renderEdges = function(start, end, options) {
-    this.renderRenderers(sigma.canvas.edges, 'edges', this.edgesOnScreen,
+    this.applyRenderers(sigma.canvas.edges, 'edges', this.edgesOnScreen,
         this.contexts.edges, start, end, options);
     if (this.settings(options, 'drawEdgeLabels')) {
-      this.renderRenderers(sigma.canvas.edges.labels, 'edges',
+      this.applyRenderers(sigma.canvas.edges.labels, 'edges',
         this.edgesOnScreen, this.contexts.labels, start, end, options);
     }
   };
@@ -310,14 +310,14 @@
     // Draw nodes:
     // - No batching
     if (drawNodes) {
-      this.renderRenderers(sigma.canvas.nodes, 'nodes', this.nodesOnScreen,
+      this.applyRenderers(sigma.canvas.nodes, 'nodes', this.nodesOnScreen,
         this.contexts.nodes, 0, this.nodesOnScreen.length, options);
     }
 
     // Draw labels:
     // - No batching
     if (drawLabels) {
-      this.renderRenderers(sigma.canvas.labels, 'nodes', this.nodesOnScreen,
+      this.applyRenderers(sigma.canvas.labels, 'nodes', this.nodesOnScreen,
         this.contexts.labels, 0, this.nodesOnScreen.length, options);
     }
 

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -132,6 +132,8 @@
     params.end = params.end || params.elements.length;
     params.end = Math.min(params.elements.length, params.end);
 
+    params.ctx.save();
+
     for (renderer in params.renderers) {
       if (params.renderers[renderer].pre) {
         params.renderers[renderer].pre(params.ctx, params.settings);
@@ -166,6 +168,8 @@
         params.renderers[renderer].post(params.ctx, params.settings);
       }
     }
+
+    params.ctx.restore();
   };
 
 

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -106,21 +106,22 @@
    * Static method to render edges or nodes with the given renderers
    *
    * @param  {object}       params     The parameters passed in an object
-   *      {
-   *        renderers:           Renderers to be used
-   *        type:                "edges" or "nodes"
-   *        ctx:                 Canvas Context to draw on
-   *        settings:            Settings object to use
-   *        elements:            Elements to render
-   *        graph:               Graph object (necessary for edge rendering)
-   *        start:    (optional) Starting index of the elements to render
-   *        end:      (optional) Last index of the elements to render
-   *      }
+   * {
+   *   renderers: {object}              Renderers indexed by types
+   *   type:      {string}              "edges" or "nodes"
+   *   ctx:       {Context2D}           Canvas Context to draw on
+   *   settings:  {object}              Settings object to use
+   *   elements:  {array}               Elements to render
+   *   graph?:    {sigma.classes.graph} Graph object
+   *                                    (only necessary for edge rendering)
+   *   start?:    {integer}             Starting index of the elements to render
+   *   end?:      {integer}             Last index of the elements to render
+   * }
    */
   sigma.renderers.canvas.applyRenderers = function(params) {
     var i,
         renderer,
-        specialized_renderer,
+        specializedRenderer,
         def,
         render,
         els = params.elements,
@@ -138,10 +139,10 @@
     }
     for (i = params.start; i < params.end; i++) {
       if (!els[i].hidden) {
-        specialized_renderer = params.renderers[
+        specializedRenderer = params.renderers[
           els[i].type || params.settings(params.options, elementType)
         ];
-        def = (specialized_renderer || params.renderers.def);
+        def = (specializedRenderer || params.renderers.def);
         render = (def.render || def);
         if (params.type == 'edges') {
           render(
@@ -171,10 +172,9 @@
   /**
    * Render a batch of edges
    *
-   * @param    {integer}               start   Starting index of the edges
-   *                                           to render
-   * @param    {integer}               end     An object of options.
-   * @param    {object}                options An object of options.
+   * @param    {integer}      start    Starting index of the elements to render
+   * @param    {integer}      end      Last index of the elements to render
+   * @param    {object}       settings Settings to use
    */
   sigma.renderers.canvas.prototype.renderEdges =
           function(start, end, settings) {

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -188,8 +188,6 @@
   sigma.renderers.canvas.prototype.render = function(options) {
     options = options || {};
 
-    this.dispatchEvent('beforeRender');
-
     var a,
         i,
         k,

--- a/src/renderers/sigma.renderers.webgl.js
+++ b/src/renderers/sigma.renderers.webgl.js
@@ -449,14 +449,13 @@
         }, key);
       };
 
-      for (i = 0, l = a.length; i < l; i++)
-        if (!a[i].hidden)
-          (
-            sigma.canvas.labels[
-              a[i].type ||
-              this.settings(options, 'defaultNodeType')
-            ] || sigma.canvas.labels.def
-          )(a[i], this.contexts.labels, o);
+      sigma.renderers.canvas.applyRenderers({
+        renderers: sigma.canvas.labels,
+        type: 'nodes',
+        ctx: this.contexts.labels,
+        elements: a,
+        settings: o
+      });
     }
 
     this.dispatchEvent('render');


### PR DESCRIPTION
Following [an issue on linkurious.js](https://github.com/Linkurious/linkurious.js/issues/169), here's a backward-compatible change to the canvas renderer allowing `pre` and `post` hooks to the renderers.

It's mainly useful for improving performance. It's used to be able to do pre-computation in the renderers.

It's already implemented in the svg and webgl renderers in some way (update/create in the svg renderer for example).

You can see how I doubled the performance of the performance via this fix in this edges label renderer for example: https://github.com/Linkurious/linkurious.js/blob/bench/edge-labels/bench/final.js