### PR TITLE
Fix example code in sigma.plugins.dragNodes README

### DIFF
--- a/plugins/sigma.plugins.dragNodes/README.md
+++ b/plugins/sigma.plugins.dragNodes/README.md
@@ -16,7 +16,7 @@ var dragListener = new sigma.plugins.dragNodes(sigInst, renderer);
 Kill the plugin as follows:
 
 ````javascript
-sigma.plugins.killDragNodes();
+sigma.plugins.killDragNodes(sigInst);
 ````
 
 ## Events


### PR DESCRIPTION
The `killDragNodes` function actually takes a sigma instance as the argument. Without passing in the sigma instance the function will fail with `Uncaught TypeError: Cannot read property 'id' of undefined` at `sigma.plugins.dragNodes.js:302`.