### PR TITLE
Add support for HDPI screens

### DIFF
--- a/src/captors/sigma.captors.mouse.js
+++ b/src/captors/sigma.captors.mouse.js
@@ -94,58 +94,51 @@
           pos;
 
       // Dispatch event:
-      if (_settings('mouseEnabled'))
-        _self.dispatchEvent('mousemove', {
-          x: sigma.utils.getX(e) - sigma.utils.getWidth(e) / 2,
-          y: sigma.utils.getY(e) - sigma.utils.getHeight(e) / 2,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          ctrlKey: e.ctrlKey,
-          metaKey: e.metaKey,
-          altKey: e.altKey,
-          shiftKey: e.shiftKey
-        });
+      if (_settings('mouseEnabled')) {
+        _self.dispatchEvent('mousemove',
+          sigma.utils.mouseCoords(e));
 
-      if (_settings('mouseEnabled') && _isMouseDown) {
-        _isMoving = true;
-        _hasDragged = true;
+        if (_isMouseDown) {
+          _isMoving = true;
+          _hasDragged = true;
 
-        if (_movingTimeoutId)
-          clearTimeout(_movingTimeoutId);
+          if (_movingTimeoutId)
+            clearTimeout(_movingTimeoutId);
 
-        _movingTimeoutId = setTimeout(function() {
-          _isMoving = false;
-        }, _settings('dragTimeout'));
+          _movingTimeoutId = setTimeout(function() {
+            _isMoving = false;
+          }, _settings('dragTimeout'));
 
-        sigma.misc.animation.killAll(_camera);
+          sigma.misc.animation.killAll(_camera);
 
-        _camera.isMoving = true;
-        pos = _camera.cameraPosition(
-          sigma.utils.getX(e) - _startMouseX,
-          sigma.utils.getY(e) - _startMouseY,
-          true
-        );
+          _camera.isMoving = true;
+          pos = _camera.cameraPosition(
+            sigma.utils.getX(e) - _startMouseX,
+            sigma.utils.getY(e) - _startMouseY,
+            true
+          );
 
-        x = _startCameraX - pos.x;
-        y = _startCameraY - pos.y;
+          x = _startCameraX - pos.x;
+          y = _startCameraY - pos.y;
 
-        if (x !== _camera.x || y !== _camera.y) {
-          _lastCameraX = _camera.x;
-          _lastCameraY = _camera.y;
+          if (x !== _camera.x || y !== _camera.y) {
+            _lastCameraX = _camera.x;
+            _lastCameraY = _camera.y;
 
-          _camera.goTo({
-            x: x,
-            y: y
-          });
+            _camera.goTo({
+              x: x,
+              y: y
+            });
+          }
+
+          if (e.preventDefault)
+            e.preventDefault();
+          else
+            e.returnValue = false;
+
+          e.stopPropagation();
+          return false;
         }
-
-        if (e.preventDefault)
-          e.preventDefault();
-        else
-          e.returnValue = false;
-
-        e.stopPropagation();
-        return false;
       }
     }
 
@@ -190,16 +183,8 @@
             y: _camera.y
           });
 
-        _self.dispatchEvent('mouseup', {
-          x: x - sigma.utils.getWidth(e) / 2,
-          y: y - sigma.utils.getHeight(e) / 2,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          ctrlKey: e.ctrlKey,
-          metaKey: e.metaKey,
-          altKey: e.altKey,
-          shiftKey: e.shiftKey
-        });
+        _self.dispatchEvent('mouseup',
+          sigma.utils.mouseCoords(e));
 
         // Update _isMoving flag:
         _isMoving = false;
@@ -233,32 +218,16 @@
             break;
           case 3:
             // Right mouse button pressed
-            _self.dispatchEvent('rightclick', {
-              x: _startMouseX - sigma.utils.getWidth(e) / 2,
-              y: _startMouseY - sigma.utils.getHeight(e) / 2,
-              clientX: e.clientX,
-              clientY: e.clientY,
-              ctrlKey: e.ctrlKey,
-              metaKey: e.metaKey,
-              altKey: e.altKey,
-              shiftKey: e.shiftKey
-            });
+            _self.dispatchEvent('rightclick',
+              sigma.utils.mouseCoords(e, _startMouseX, _startMouseY));
             break;
           // case 1:
           default:
             // Left mouse button pressed
             _isMouseDown = true;
 
-            _self.dispatchEvent('mousedown', {
-              x: _startMouseX - sigma.utils.getWidth(e) / 2,
-              y: _startMouseY - sigma.utils.getHeight(e) / 2,
-              clientX: e.clientX,
-              clientY: e.clientY,
-              ctrlKey: e.ctrlKey,
-              metaKey: e.metaKey,
-              altKey: e.altKey,
-              shiftKey: e.shiftKey
-            });
+            _self.dispatchEvent('mousedown',
+              sigma.utils.mouseCoords(e, _startMouseX, _startMouseY));
         }
       }
     }
@@ -281,20 +250,12 @@
      * @param {event} e A mouse event.
      */
     function _clickHandler(e) {
-      if (_settings('mouseEnabled'))
-        _self.dispatchEvent('click', {
-          x: sigma.utils.getX(e) - sigma.utils.getWidth(e) / 2,
-          y: sigma.utils.getY(e) - sigma.utils.getHeight(e) / 2,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          ctrlKey: e.ctrlKey,
-          metaKey: e.metaKey,
-          altKey: e.altKey,
-          shiftKey: e.shiftKey,
-          isDragging:
-            (((new Date()).getTime() - _downStartTime) > 100) &&
-            _hasDragged
-        });
+      if (_settings('mouseEnabled')) {
+        var event = sigma.utils.mouseCoords(e);
+        event.isDragging =
+          (((new Date()).getTime() - _downStartTime) > 100) && _hasDragged;
+        _self.dispatchEvent('click', event);
+      }
 
       if (e.preventDefault)
         e.preventDefault();
@@ -319,21 +280,13 @@
       if (_settings('mouseEnabled')) {
         ratio = 1 / _settings('doubleClickZoomingRatio');
 
-        _self.dispatchEvent('doubleclick', {
-          x: _startMouseX - sigma.utils.getWidth(e) / 2,
-          y: _startMouseY - sigma.utils.getHeight(e) / 2,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          ctrlKey: e.ctrlKey,
-          metaKey: e.metaKey,
-          altKey: e.altKey,
-          shiftKey: e.shiftKey
-        });
+        _self.dispatchEvent('doubleclick',
+            sigma.utils.mouseCoords(e, _startMouseX, _startMouseY));
 
         if (_settings('doubleClickEnabled')) {
           pos = _camera.cameraPosition(
-            sigma.utils.getX(e) - sigma.utils.getWidth(e) / 2,
-            sigma.utils.getY(e) - sigma.utils.getHeight(e) / 2,
+            sigma.utils.getX(e) - sigma.utils.getCenter(e).x,
+            sigma.utils.getY(e) - sigma.utils.getCenter(e).y,
             true
           );
 
@@ -371,8 +324,8 @@
           _settings('zoomingRatio');
 
         pos = _camera.cameraPosition(
-          sigma.utils.getX(e) - sigma.utils.getWidth(e) / 2,
-          sigma.utils.getY(e) - sigma.utils.getHeight(e) / 2,
+          sigma.utils.getX(e) - sigma.utils.getCenter(e).x,
+          sigma.utils.getY(e) - sigma.utils.getCenter(e).y,
           true
         );
 

--- a/src/captors/sigma.captors.touch.js
+++ b/src/captors/sigma.captors.touch.js
@@ -73,9 +73,6 @@
       };
     }
 
-
-
-
     /**
      * This method unbinds every handlers that makes the captor work.
      */
@@ -87,9 +84,6 @@
       _target.addEventListener('touchleave', _handleLeave);
       _target.addEventListener('touchmove', _handleMove);
     };
-
-
-
 
     // TOUCH EVENTS:
     // *************
@@ -156,8 +150,10 @@
               _startTouchX1 - _startTouchX0
             );
             _startTouchDistance = Math.sqrt(
-              Math.pow(_startTouchY1 - _startTouchY0, 2) +
-              Math.pow(_startTouchX1 - _startTouchX0, 2)
+              (_startTouchY1 - _startTouchY0) *
+                (_startTouchY1 - _startTouchY0) +
+              (_startTouchX1 - _startTouchX0) *
+                (_startTouchX1 - _startTouchX0)
             );
 
             e.preventDefault();
@@ -281,16 +277,8 @@
                 y: newStageY
               });
 
-              _self.dispatchEvent('mousemove', {
-                x: pos0.x - sigma.utils.getWidth(e) / 2,
-                y: pos0.y - sigma.utils.getHeight(e) / 2,
-                clientX: e.clientX,
-                clientY: e.clientY,
-                ctrlKey: e.ctrlKey,
-                metaKey: e.metaKey,
-                altKey: e.altKey,
-                shiftKey: e.shiftKey
-              });
+              _self.dispatchEvent('mousemove',
+                sigma.utils.mouseCoords(e, pos0.x, pos0.y));
 
               _self.dispatchEvent('drag');
             }
@@ -305,20 +293,20 @@
 
             start = _camera.cameraPosition(
               (_startTouchX0 + _startTouchX1) / 2 -
-                sigma.utils.getWidth(e) / 2,
+                sigma.utils.getCenter(e).x,
               (_startTouchY0 + _startTouchY1) / 2 -
-                sigma.utils.getHeight(e) / 2,
+                sigma.utils.getCenter(e).y,
               true
             );
             end = _camera.cameraPosition(
-              (x0 + x1) / 2 - sigma.utils.getWidth(e) / 2,
-              (y0 + y1) / 2 - sigma.utils.getHeight(e) / 2,
+              (x0 + x1) / 2 - sigma.utils.getCenter(e).x,
+              (y0 + y1) / 2 - sigma.utils.getCenter(e).y,
               true
             );
 
             dAngle = Math.atan2(y1 - y0, x1 - x0) - _startTouchAngle;
             dRatio = Math.sqrt(
-              Math.pow(y1 - y0, 2) + Math.pow(x1 - x0, 2)
+              (y1 - y0) * (y1 - y0) + (x1 - x0) * (x1 - x0)
             ) / _startTouchDistance;
 
             // Translation:
@@ -389,21 +377,13 @@
         ratio = 1 / _settings('doubleClickZoomingRatio');
 
         pos = position(e.touches[0]);
-        _self.dispatchEvent('doubleclick', {
-          x: pos.x - sigma.utils.getWidth(e) / 2,
-          y: pos.y - sigma.utils.getHeight(e) / 2,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          ctrlKey: e.ctrlKey,
-          metaKey: e.metaKey,
-          altKey: e.altKey,
-          shiftKey: e.shiftKey
-        });
+        _self.dispatchEvent('doubleclick',
+          sigma.utils.mouseCoords(e, pos.x, pos.y));
 
         if (_settings('doubleClickEnabled')) {
           pos = _camera.cameraPosition(
-            pos.x - sigma.utils.getWidth(e) / 2,
-            pos.y - sigma.utils.getHeight(e) / 2,
+            pos.x - sigma.utils.getCenter(e).x,
+            pos.y - sigma.utils.getCenter(e).y,
             true
           );
 

--- a/src/misc/sigma.misc.drawHovers.js
+++ b/src/misc/sigma.misc.drawHovers.js
@@ -51,14 +51,13 @@
     });
 
     function draw() {
-      // Clear self.contexts.hover:
-      self.contexts.hover.canvas.width = self.contexts.hover.canvas.width;
 
       var k,
           source,
           target,
           hoveredNode,
           hoveredEdge,
+          c = self.contexts.hover.canvas,
           defaultNodeType = self.settings('defaultNodeType'),
           defaultEdgeType = self.settings('defaultEdgeType'),
           nodeRenderers = sigma.canvas.hovers,
@@ -67,6 +66,9 @@
           embedSettings = self.settings.embedObjects({
             prefix: prefix
           });
+
+      // Clear self.contexts.hover:
+      self.contexts.hover.clearRect(0, 0, c.width, c.height);
 
       // Node render: single hover
       if (

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -359,13 +359,7 @@
     var k,
         oldWidth = this.width,
         oldHeight = this.height,
-        pixelRatio = 1;
-        // TODO:
-        // *****
-        // This pixelRatio is the solution to display with the good definition
-        // on canvases on Retina displays (ie oversampling). Unfortunately, it
-        // has a huge performance cost...
-        //  > pixelRatio = window.devicePixelRatio || 1;
+        pixelRatio = sigma.utils.getPixelRatio();
 
     if (w !== undefined && h !== undefined) {
       this.width = w;
@@ -402,11 +396,9 @@
    * @return {sigma.renderers.canvas} Returns the instance itself.
    */
   sigma.renderers.canvas.prototype.clear = function() {
-    var k;
-
-    for (k in this.domElements)
-      if (this.domElements[k].tagName === 'CANVAS')
-        this.domElements[k].width = this.domElements[k].width;
+    for (var k in this.contexts) {
+      this.contexts[k].clearRect(0, 0, this.width, this.height);
+    }
 
     return this;
   };

--- a/src/renderers/sigma.renderers.webgl.js
+++ b/src/renderers/sigma.renderers.webgl.js
@@ -517,7 +517,8 @@
   sigma.renderers.webgl.prototype.resize = function(w, h) {
     var k,
         oldWidth = this.width,
-        oldHeight = this.height;
+        oldHeight = this.height,
+        pixelRatio = sigma.utils.getPixelRatio();
 
     if (w !== undefined && h !== undefined) {
       this.width = w;
@@ -538,8 +539,11 @@
         if (this.domElements[k].tagName.toLowerCase() === 'canvas') {
           // If simple 2D canvas:
           if (this.contexts[k] && this.contexts[k].scale) {
-            this.domElements[k].setAttribute('width', w + 'px');
-            this.domElements[k].setAttribute('height', h + 'px');
+            this.domElements[k].setAttribute('width', (w * pixelRatio) + 'px');
+            this.domElements[k].setAttribute('height', (h * pixelRatio) + 'px');
+
+            if (pixelRatio !== 1)
+              this.contexts[k].scale(pixelRatio, pixelRatio);
           } else {
             this.domElements[k].setAttribute(
               'width',
@@ -573,12 +577,7 @@
    * @return {sigma.renderers.webgl} Returns the instance itself.
    */
   sigma.renderers.webgl.prototype.clear = function() {
-    var k;
-
-    for (k in this.domElements)
-      if (this.domElements[k].tagName === 'CANVAS')
-        this.domElements[k].width = this.domElements[k].width;
-
+    this.contexts.labels.clearRect(0, 0, this.width, this.height);
     this.contexts.nodes.clear(this.contexts.nodes.COLOR_BUFFER_BIT);
     this.contexts.edges.clear(this.contexts.edges.COLOR_BUFFER_BIT);
 

--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -632,7 +632,7 @@
    * @return {object}   The center of the event's target.
    */
   sigma.utils.getCenter = function(e) {
-    var ratio = e.target.getAttribute('class') == 'sigma-svg' ? 1 :
+    var ratio = e.target.namespaceURI.indexOf('svg') !== -1 ? 1 :
         sigma.utils.getPixelRatio();
     return {
       x: sigma.utils.getWidth(e) / (2 * ratio),

--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -591,6 +591,24 @@
   };
 
   /**
+   * The pixel ratio of the screen. Taking zoom into account
+   *
+   * @return {number}        Pixel ratio of the screen
+   */
+  sigma.utils.getPixelRatio = function() {
+    var ratio = 1;
+    if (window.screen.deviceXDPI !== undefined &&
+         window.screen.logicalXDPI !== undefined &&
+         window.screen.deviceXDPI > window.screen.logicalXDPI) {
+        ratio = window.screen.systemXDPI / window.screen.logicalXDPI;
+    }
+    else if (window.devicePixelRatio !== undefined) {
+        ratio = window.devicePixelRatio;
+    }
+    return ratio;
+  };
+
+  /**
    * Extract the width from a mouse or touch event.
    *
    * @param  {event}  e A mouse or touch event.
@@ -605,6 +623,45 @@
       (typeof w === 'number' && w) ||
       (w !== undefined && w.baseVal !== undefined && w.baseVal.value)
     );
+  };
+
+  /**
+   * Extract the center from a mouse or touch event.
+   *
+   * @param  {event}  e A mouse or touch event.
+   * @return {object}   The center of the event's target.
+   */
+  sigma.utils.getCenter = function(e) {
+    var ratio = e.target.getAttribute('class') == 'sigma-svg' ? 1 :
+        sigma.utils.getPixelRatio();
+    return {
+      x: sigma.utils.getWidth(e) / (2 * ratio),
+      y: sigma.utils.getHeight(e) / (2 * ratio),
+    };
+  };
+
+  /**
+   * Convert mouse coords to sigma coords
+   *
+   * @param  {event}   e A mouse or touch event.
+   * @param  {number?} x The x coord to convert
+   * @param  {number?} x The y coord to convert
+   *
+   * @return {object}    The standardized event
+   */
+  sigma.utils.mouseCoords = function(e, x, y) {
+    x = x || sigma.utils.getX(e);
+    y = y || sigma.utils.getY(e);
+    return {
+        x: x - sigma.utils.getCenter(e).x,
+        y: y - sigma.utils.getCenter(e).y,
+        clientX: e.clientX,
+        clientY: e.clientY,
+        ctrlKey: e.ctrlKey,
+        metaKey: e.metaKey,
+        altKey: e.altKey,
+        shiftKey: e.shiftKey
+    };
   };
 
   /**


### PR DESCRIPTION
Fix #180 *retina display support*

- canvas renderer use pixelratio
- webgl label renderer too
- events have the good coordinates (+little refactoring)

All of this because we use ctx.scale() each time we resize and then we can draw like before.

**NOTE: originally developed for linkurious.js**