### PR TITLE
Fixes for FA2 adjustSizes functionality

### DIFF
--- a/plugins/sigma.layout.forceAtlas2/supervisor.js
+++ b/plugins/sigma.layout.forceAtlas2/supervisor.js
@@ -123,6 +123,7 @@
         nbytes = nodes.length * this.ppn,
         ebytes = edges.length * this.ppe,
         nIndex = {},
+        prefix = this.sigInst.renderers[0].options.prefix,
         i,
         j,
         l;
@@ -138,16 +139,16 @@
       nIndex[nodes[i].id] = j;
 
       // Populating byte array
-      this.nodesByteArray[j] = nodes[i].x;
-      this.nodesByteArray[j + 1] = nodes[i].y;
+      this.nodesByteArray[j] = this.randomize(nodes[i][prefix + 'x']);
+      this.nodesByteArray[j + 1] = this.randomize(nodes[i][prefix + 'y']);
       this.nodesByteArray[j + 2] = 0;
       this.nodesByteArray[j + 3] = 0;
       this.nodesByteArray[j + 4] = 0;
       this.nodesByteArray[j + 5] = 0;
       this.nodesByteArray[j + 6] = 1 + this.graph.degree(nodes[i].id);
       this.nodesByteArray[j + 7] = 1;
-      this.nodesByteArray[j + 8] = nodes[i].size;
-      this.nodesByteArray[j + 9] = 0;
+      this.nodesByteArray[j + 8] = nodes[i][prefix + 'size'];
+      this.nodesByteArray[j + 9] = nodes[i].fixed || 0;
       j += this.ppn;
     }
 

--- a/plugins/sigma.layout.forceAtlas2/supervisor.js
+++ b/plugins/sigma.layout.forceAtlas2/supervisor.js
@@ -139,8 +139,8 @@
       nIndex[nodes[i].id] = j;
 
       // Populating byte array
-      this.nodesByteArray[j] = this.randomize(nodes[i][prefix + 'x']);
-      this.nodesByteArray[j + 1] = this.randomize(nodes[i][prefix + 'y']);
+      this.nodesByteArray[j] = nodes[i][prefix + 'x'];
+      this.nodesByteArray[j + 1] = nodes[i][prefix + 'y'];
       this.nodesByteArray[j + 2] = 0;
       this.nodesByteArray[j + 3] = 0;
       this.nodesByteArray[j + 4] = 0;

--- a/plugins/sigma.layout.forceAtlas2/worker.js
+++ b/plugins/sigma.layout.forceAtlas2/worker.js
@@ -746,10 +746,9 @@
         if (W.settings.adjustSizes) {
 
           distance = Math.sqrt(
-            (Math.pow(xDist, 2) + Math.pow(yDist, 2)) -
+            (Math.pow(xDist, 2) + Math.pow(yDist, 2))) -
             NodeMatrix[np(n1, 'size')] -
-            NodeMatrix[np(n2, 'size')]
-          );
+            NodeMatrix[np(n2, 'size')];
 
           if (W.settings.linLogMode) {
             if (W.settings.outboundAttractionDistribution) {

--- a/plugins/sigma.layout.forceAtlas2/worker.js
+++ b/plugins/sigma.layout.forceAtlas2/worker.js
@@ -857,13 +857,6 @@
               Math.pow(NodeMatrix[np(n, 'dy')], 2)
             );
 
-            if (force > W.maxForce) {
-              NodeMatrix[np(n, 'dx')] =
-                NodeMatrix[np(n, 'dx')] * W.maxForce / force;
-              NodeMatrix[np(n, 'dy')] =
-                NodeMatrix[np(n, 'dy')] * W.maxForce / force;
-            }
-
             swinging = NodeMatrix[np(n, 'mass')] *
               Math.sqrt(
                 (NodeMatrix[np(n, 'old_dx')] - NodeMatrix[np(n, 'dx')]) *
@@ -881,6 +874,10 @@
 
             nodespeed =
               0.1 * Math.log(1 + traction) / (1 + Math.sqrt(swinging));
+
+            if(nodespeed > (W.maxForce * W.settings.slowDown / force) ) {
+              nodespeed = W.maxForce * W.settings.slowDown / force;
+            }
 
             // Updating node's positon
             NodeMatrix[np(n, 'x')] =

--- a/plugins/sigma.layout.forceAtlas2/worker.js
+++ b/plugins/sigma.layout.forceAtlas2/worker.js
@@ -647,8 +647,8 @@
                 NodeMatrix[np(n1, 'dx')] += xDist * factor;
                 NodeMatrix[np(n1, 'dy')] += yDist * factor;
 
-                NodeMatrix[np(n2, 'dx')] += xDist * factor;
-                NodeMatrix[np(n2, 'dy')] += yDist * factor;
+                NodeMatrix[np(n2, 'dx')] -= xDist * factor;
+                NodeMatrix[np(n2, 'dy')] -= yDist * factor;
               }
               else if (distance < 0) {
                 factor = 100 * coefficient *


### PR DESCRIPTION
As per this discussion: https://github.com/jacomyal/sigma.js/issues/720

@Yomguithereal please note:

1. This line is clearly a hack: `prefix = this.sigInst.renderers[0].options.prefix`. I tried using rendererIndex as for the noverlap layout instead of this hardcoded zero but for some reason FA2 didn't like that approach...you may have more luck. Whenever a distance computation involving node size is involved I think we should be using rendered sizes and co-ordinates however.  
2. The computation of forces now seems in line with the Gephi algorithm here: https://github.com/gephi/gephi/tree/master/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2. However, the application of forces seems very different...I can see the parallels but there are enough differences to make it hard to follow directly. The change I made regarding maxForce seems to bring it a bit more in line with Gephi and fixed a bug for me...but, like I said, it's different...
3. Let me know if adjustSizes with Barnes-Hut on is working for you...I'm still having a bit of an issue with that. 