### PR TITLE
Bump http-server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "load-grunt-tasks": "~0.6.0",
     "grunt-sed": "~0.1.1",
     "grunt-zip": "~0.15.0",
-    "http-server": "~0.6.1",
+    "http-server": "~0.9.0",
     "grunt-grunt": "^0.2.2",
     "uglify-js": "^2.4.15"
   },


### PR DESCRIPTION
There is a [known bug](https://github.com/indexzero/http-server/issues/244) on http-server which could break the demo server.
It fix issue #724