### PR TITLE
Fast node/edge removal

### DIFF
--- a/src/classes/sigma.classes.graph.js
+++ b/src/classes/sigma.classes.graph.js
@@ -60,7 +60,7 @@
       edgesIndex: Object.create(null),
 
       /**
-       * This index maps node ids into a dictionary that maps adjacent edges ids
+       * This index maps node ids into dictionaries that map adjacent edges ids
        * into edges.
        * Useful for quick node removal.
        */

--- a/src/classes/sigma.classes.graph.js
+++ b/src/classes/sigma.classes.graph.js
@@ -60,9 +60,9 @@
       edgesIndex: Object.create(null),
 
       /**
-       * This index maps node id into a dictionary that maps adjacent edges ids
+       * This index maps node ids into a dictionary that maps adjacent edges ids
        * into edges.
-       * Useful for for quick node removal.
+       * Useful for quick node removal.
        */
       allAdjacentEdgesIndex: Object.create(null),
 

--- a/src/classes/sigma.classes.graph.js
+++ b/src/classes/sigma.classes.graph.js
@@ -410,7 +410,7 @@
     this.outNeighborsCount[id] = 0;
     this.allNeighborsCount[id] = 0;
 
-    this.allAdjacentEdgesIndex[validNode.id] = {}
+    this.allAdjacentEdgesIndex[validNode.id] = {};
 
     // Add the node to indexes:
     this.nodesIndex[validNode.id] = validNode;
@@ -485,8 +485,8 @@
       validEdge.target = edge.target;
     }
 
-    this.allAdjacentEdgesIndex[validEdge.source][validEdge.id] = validEdge
-    this.allAdjacentEdgesIndex[validEdge.target][validEdge.id] = validEdge
+    this.allAdjacentEdgesIndex[validEdge.source][validEdge.id] = validEdge;
+    this.allAdjacentEdgesIndex[validEdge.target][validEdge.id] = validEdge;
 
     // Add the edge to indexes:
     this.edgesIndex[validEdge.id] = validEdge;
@@ -549,12 +549,12 @@
     delete this.nodesIndex[id];
 
     // Remove related edges:
-    var edge_ids = []
+    var edge_ids = [];
     for (i in this.allAdjacentEdgesIndex[id]) {
-      edge_ids.push(i)
+      edge_ids.push(i);
     }
     for (k in edge_ids) {
-      this.dropEdge(edge_ids[k])
+      this.dropEdge(edge_ids[k]);
     }
 
     // Remove related edge indexes:
@@ -817,7 +817,7 @@
     if (!arguments.length) {
       var edges = [];
       for (var id in this.edgesIndex) {
-	  edges.push(this.edgesIndex[id]);
+        edges.push(this.edgesIndex[id]);
       }
       return edges;
     }


### PR DESCRIPTION
The changes allow for fast node and edge removal (time proportional to the number of removed edges/nodes).

In order to implement it I needed to remove the nodesArray and edgesArray arrays (they didn't seem to be really needed as far as I could see as the 'nodes' and 'edges' methods can construct results on the fly) and introduce the allAdjacentEdgesIndex object that maps node ids into dictionaries that map adjacent edges ids into edges.

I developed these changes for Data4Cure (http://www.data4cure.com) and the company is ok with sharing them.