### PR TITLE
Fix bug with drawLabels: false and using webgl renderer

### DIFF
--- a/src/renderers/sigma.renderers.webgl.js
+++ b/src/renderers/sigma.renderers.webgl.js
@@ -451,23 +451,23 @@
       }
     }
 
+    a = this.camera.quadtree.area(
+      this.camera.getRectangle(this.width, this.height)
+    );
+
+    // Apply camera view to these nodes:
+    this.camera.applyView(
+      undefined,
+      undefined,
+      {
+        nodes: a,
+        edges: [],
+        width: this.width,
+        height: this.height
+      }
+    );
+
     if (drawLabels) {
-      a = this.camera.quadtree.area(
-        this.camera.getRectangle(this.width, this.height)
-      );
-
-      // Apply camera view to these nodes:
-      this.camera.applyView(
-        undefined,
-        undefined,
-        {
-          nodes: a,
-          edges: [],
-          width: this.width,
-          height: this.height
-        }
-      );
-
       o = function(key) {
         return self.settings({
           prefix: self.camera.prefix


### PR DESCRIPTION
Bug: When `drawLabels: false` is set, and the webgl renderer is used, some pointer events mess up (such as mouse hovering or click events).

This PR addressed this issues.
