### PR TITLE
fix unexpected zoom behaviors on macbook pro trackpads fix #790

### DIFF
--- a/src/captors/sigma.captors.mouse.js
+++ b/src/captors/sigma.captors.mouse.js
@@ -320,7 +320,7 @@
           wheelDelta = sigma.utils.getDelta(e);
 
       if (_settings('mouseEnabled') && _settings('mouseWheelEnabled') && wheelDelta !== 0) {
-        ratio = sigma.utils.getDelta(e) > 0 ?
+        ratio = wheelDelta > 0 ?
           1 / _settings('zoomingRatio') :
           _settings('zoomingRatio');
 

--- a/src/captors/sigma.captors.mouse.js
+++ b/src/captors/sigma.captors.mouse.js
@@ -316,9 +316,10 @@
     function _wheelHandler(e) {
       var pos,
           ratio,
-          animation;
+          animation,
+          wheelDelta = sigma.utils.getDelta(e);
 
-      if (_settings('mouseEnabled') && _settings('mouseWheelEnabled')) {
+      if (_settings('mouseEnabled') && _settings('mouseWheelEnabled') && wheelDelta !== 0) {
         ratio = sigma.utils.getDelta(e) > 0 ?
           1 / _settings('zoomingRatio') :
           _settings('zoomingRatio');


### PR DESCRIPTION
The problem described in issue #790 seems to be related to invalid mousewheel events featuring a delta of "-0". Not processing the mousewheel events that have this characteristic seems to fix the haltingly behavior of camera when zooming on macbook pro with trackpads.