### PR TITLE
Reset filter when initialized with a new Sigma instance

### DIFF
--- a/plugins/sigma.plugins.filter/sigma.plugins.filter.js
+++ b/plugins/sigma.plugins.filter/sigma.plugins.filter.js
@@ -494,10 +494,9 @@
    * @param  {sigma} s The related sigma instance.
    */
   sigma.plugins.filter = function(s) {
-    // Create filter if undefined
-    if (!filter) {
-      filter = new Filter(s);
-    }
+    // Create new filter to update the graph params. Be aware, filter is a singleton,
+    // therefore filter instance can work on one sigma instance at a time.
+    filter = new Filter(s);
     return filter;
   };
 


### PR DESCRIPTION
Hi, currently filter graph is a singleton object without possibility to reset it to other sigma instance when needed. This fix allows to reassign filter to the sigma instance provided in the factory method as it is supposed by developer.
e.g. it fixes the case:

```
let s1 = new sigma();
let s2 = new sigma();
...
f1 = new sigma.plugins.filter(s1)
...
f1.apply()
f2 = new sigma.plugins.filter(s2)
...
f2.apply() // Actually Filter will be applied to s1.graph, rather than to s2.graph
```

Thanks,
Maxim