### PR TITLE
fix rendering of exported svg on some viewers

### DIFF
--- a/plugins/sigma.exporters.svg/sigma.exporters.svg.js
+++ b/plugins/sigma.exporters.svg/sigma.exporters.svg.js
@@ -90,6 +90,7 @@
     // Creating style tag if needed
     if (params.classes) {
       style = document.createElementNS(XMLNS, 'style');
+      style.setAttribute('type', 'text/css')
       svg.insertBefore(style, svg.firstChild);
     }
 


### PR DESCRIPTION
E.g. before this Eyes of Gnome was unable to interpret the `style` element. With this PR the svg is correctly displayed