### PR TITLE
Added the option to filter the nodes and edges used in forceAtlas

### DIFF
--- a/examples/forceFiltered.html
+++ b/examples/forceFiltered.html
@@ -1,0 +1,147 @@
+<!-- START SIGMA IMPORTS -->
+<script src="../src/sigma.core.js"></script>
+<script src="../src/conrad.js"></script>
+<script src="../src/utils/sigma.utils.js"></script>
+<script src="../src/utils/sigma.polyfills.js"></script>
+<script src="../src/sigma.settings.js"></script>
+<script src="../src/classes/sigma.classes.dispatcher.js"></script>
+<script src="../src/classes/sigma.classes.configurable.js"></script>
+<script src="../src/classes/sigma.classes.graph.js"></script>
+<script src="../src/classes/sigma.classes.camera.js"></script>
+<script src="../src/classes/sigma.classes.quad.js"></script>
+<script src="../src/classes/sigma.classes.edgequad.js"></script>
+<script src="../src/captors/sigma.captors.mouse.js"></script>
+<script src="../src/captors/sigma.captors.touch.js"></script>
+<script src="../src/renderers/sigma.renderers.canvas.js"></script>
+<script src="../src/renderers/sigma.renderers.webgl.js"></script>
+<script src="../src/renderers/sigma.renderers.svg.js"></script>
+<script src="../src/renderers/sigma.renderers.def.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.nodes.def.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.nodes.fast.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.edges.def.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.edges.fast.js"></script>
+<script src="../src/renderers/webgl/sigma.webgl.edges.arrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.labels.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.hovers.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.nodes.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edges.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edges.curve.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edges.arrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edges.curvedArrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edgehovers.def.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edgehovers.curve.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edgehovers.arrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.edgehovers.curvedArrow.js"></script>
+<script src="../src/renderers/canvas/sigma.canvas.extremities.def.js"></script>
+<script src="../src/renderers/svg/sigma.svg.utils.js"></script>
+<script src="../src/renderers/svg/sigma.svg.nodes.def.js"></script>
+<script src="../src/renderers/svg/sigma.svg.edges.def.js"></script>
+<script src="../src/renderers/svg/sigma.svg.edges.curve.js"></script>
+<script src="../src/renderers/svg/sigma.svg.labels.def.js"></script>
+<script src="../src/renderers/svg/sigma.svg.hovers.def.js"></script>
+<script src="../src/middlewares/sigma.middlewares.rescale.js"></script>
+<script src="../src/middlewares/sigma.middlewares.copy.js"></script>
+<script src="../src/misc/sigma.misc.animation.js"></script>
+<script src="../src/misc/sigma.misc.bindEvents.js"></script>
+<script src="../src/misc/sigma.misc.bindDOMEvents.js"></script>
+<script src="../src/misc/sigma.misc.drawHovers.js"></script>
+<!-- END SIGMA IMPORTS -->
+<div id="container">
+  <style>
+    #graph-container {
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      position: absolute;
+    }
+  </style>
+  <div id="graph-container"></div>
+</div>
+<script src="../plugins/sigma.layout.forceAtlas2/worker.js"></script>
+<script src="../plugins/sigma.layout.forceAtlas2/supervisor.js"></script>
+<script>
+/**
+ * Just a simple example to show how to use the sigma.layout.forceAtlas2
+ * plugin:
+ *
+ * A random graph is generated, such that its nodes are separated in some
+ * distinct clusters. Each cluster has its own color, and the density of
+ * links is stronger inside the clusters. So, we expect the algorithm to
+ * regroup the nodes of each cluster.
+ */
+var i,
+    s,
+    o,
+    N = 100,
+    E = 500,
+    C = 5,
+    d = 0.7,
+    cs = [],
+    g = {
+      nodes: [],
+      edges: []
+    };
+
+// Generate the graph:
+for (i = 0; i < C; i++)
+  cs.push({
+    id: i,
+    nodes: [],
+    color: '#' + (
+      Math.floor(Math.random() * 16777215).toString(16) + '000000'
+    ).substr(0, 6)
+  });
+
+for (i = 0; i < N; i++) {
+  o = cs[(Math.random() * C) | 0];
+  g.nodes.push({
+    id: 'n' + i,
+    label: 'Node' + i,
+    x: 100 * Math.cos(2 * i * Math.PI / N),
+    y: 100 * Math.sin(2 * i * Math.PI / N),
+    size: Math.random(),
+    color: o.color,
+    filterType: o.id
+  });
+  o.nodes.push('n' + i);
+}
+
+for (i = 0; i < E; i++) {
+  if (Math.random() < 1 - d)
+    g.edges.push({
+      id: 'e' + i,
+      source: 'n' + ((Math.random() * N) | 0),
+      target: 'n' + ((Math.random() * N) | 0),
+      filterType: "interGraph"
+    });
+  else {
+    o = cs[(Math.random() * C) | 0];
+    g.edges.push({
+      id: 'e' + i,
+      source: o.nodes[(Math.random() * o.nodes.length) | 0],
+      target: o.nodes[(Math.random() * o.nodes.length) | 0],
+      filterType: o.id
+    });
+  }
+}
+
+s = new sigma({
+  graph: g,
+  container: 'graph-container',
+  settings: {
+    drawEdges: false
+  }
+});
+
+var nodeFilter = [];
+var edgeFilter = ["interGraph"];
+for(i = 1; i<cs.length; i++){
+  nodeFilter.push(cs[i].id);
+  edgeFilter.push(cs[i].id);
+}
+
+// Start the ForceAtlas2 algorithm:
+s.startForceAtlas2({worker: true, barnesHutOptimize: false,
+  edgeFilter:edgeFilter, nodeFilter:nodeFilter});
+</script>

--- a/plugins/sigma.layout.forceAtlas2/README.md
+++ b/plugins/sigma.layout.forceAtlas2/README.md
@@ -5,6 +5,8 @@ Algorithm by [Mathieu Jacomy](https://github.com/jacomyma).
 
 Plugin by [Guillaume Plique](https://github.com/Yomguithereal).
 
+Filter modification by [Joakim af Sandeberg](https://github.com/jotunacorn).
+
 ---
 
 This plugin implements [ForceAtlas2](http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0098679), a force-directed layout algorithm.
@@ -69,11 +71,17 @@ sigmaInstance.isForceAtlas2Running();
 * **slowDown** *number* `1`
 * **startingIterations** *integer* `1`: number of iterations to be run before the first render.
 * **iterationsPerRender** *integer* `1`: number of iterations to be run before each render.
+* **edgeFilter** *[string]* `[]`: Array of Strings to filter the edges on. Only edges with the filterType set to the same String as in the edgefilter will be used during the layout. If the array is empty all edges will be used.
+* **nodeFilter** *[string]* `[]`: Array of Strings to filter the nodes on. Only nodes with the filterType set to the same String as in the nodeFilter will be used during the layout. If the array is empty all nodes will be used.
 
 *Supervisor configuration*
 
 * **worker** *boolean* `true`: should the layout use a web worker?
 * **workerUrl** *string* : path to the worker file if needed because your browser does not support blob workers.
+
+*Edge/Node configuration*
+
+* **filterType** *String* `undefined`: String to combine with the edgeFilter/nodeFIlter in the algorithm configuration.
 
 ## Notes
 1. The layout won't stop by itself, so if you want it to stop, you will have to trigger it explicitly.


### PR DESCRIPTION
Reopen of request #726 

Adds the option to specify an edgeFilter and a nodeFilter to the forceAtlas2 layout algorithm. The filters are applied before the nodes and edges are passed to the worker. The filters are matched to the nodes and edges "filterType" property and if they are the same it will be included when doing the layout. 

Below is an example of how the demo can be used. The filter in the screenshot removes the dark-green nodes from being a part of the layout.
![2016-03-11 13-50-47](https://cloud.githubusercontent.com/assets/10715384/13702683/a678185a-e790-11e5-9076-704f3a4efde1.png)
