### PR TITLE
Added some small features

### DIFF
--- a/plugins/sigma.layout.forceAtlas2/supervisor.js
+++ b/plugins/sigma.layout.forceAtlas2/supervisor.js
@@ -168,8 +168,10 @@
 
     // Moving nodes
     for (var i = 0, l = this.nodesByteArray.length; i < l; i += this.ppn) {
-      nodes[j].x = this.nodesByteArray[i];
-      nodes[j].y = this.nodesByteArray[i + 1];
+      if(!nodes[j].isPinned){
+		  nodes[j].x = this.nodesByteArray[i];
+		  nodes[j].y = this.nodesByteArray[i + 1];
+	  }
       j++;
     }
   };

--- a/plugins/sigma.plugins.filter/sigma.plugins.filter.js
+++ b/plugins/sigma.plugins.filter/sigma.plugins.filter.js
@@ -495,9 +495,7 @@
    */
   sigma.plugins.filter = function(s) {
     // Create filter if undefined
-    if (!filter) {
-      filter = new Filter(s);
-    }
+    filter = new Filter(s);
     return filter;
   };
 

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -311,7 +311,7 @@
     if (drawLabels) {
       renderers = sigma.canvas.labels;
       for (a = this.nodesOnScreen, i = 0, l = a.length; i < l; i++)
-        if (!a[i].hidden)
+        if (!a[i].hidden && !a[i].hideLabel)
           (renderers[
             a[i].type || this.settings(options, 'defaultNodeType')
           ] || renderers.def)(

--- a/src/renderers/sigma.renderers.webgl.js
+++ b/src/renderers/sigma.renderers.webgl.js
@@ -475,7 +475,7 @@
       };
 
       for (i = 0, l = a.length; i < l; i++)
-        if (!a[i].hidden)
+        if (!a[i].hidden && !a[i].hideLabel)
           (
             sigma.canvas.labels[
               a[i].type ||


### PR DESCRIPTION
* modified 'plugins/sigma.layout.forceAtlas2/supervisor.js' to allow pinning nodes in forceAtlas2. if you set node.isPinned = true, it will not be moved when applying force atlas to the graph. this is useful for clicking and dragging nodes. (I dont recommend keeping force atlas running 24/7, but if you set a node to be pinned after dragging a node with the drag nodes plugin, it will behave as expected, rather than flying back to where it was)

* modified plugins/sigma.plugins.filter/sigma.plugins.filter.js to address the bug in issue: #654

* modified both renders so that you can set node.hideLabel = true to prevent the label from appearing on some nodes. I found that with dense graphs, the labels often cluttered the screen. Like how in the examples you can click on a node and it will shadow the non neighbors, you can also set hodeLabel on non neighbor nodes to greatly increase readability.