### PR TITLE
in dragNodes Plugins add suitable variable declaration.

### DIFF
--- a/examples/drag-nodes.html
+++ b/examples/drag-nodes.html
@@ -106,7 +106,10 @@ for (i = 0; i < E; i++)
 // Instantiate sigma:
 s = new sigma({
   graph: g,
-  container: 'graph-container'
+  renderer: {
+    container: 'graph-container',
+    type: 'webgl'
+  }
 });
 
 // Initialize the dragNodes plugin:

--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -54,7 +54,10 @@
       _mouse = renderer.container.lastChild,
       _camera = renderer.camera,
       _node = null,
-      _prefix = '',
+      _prefix = sigma.renderers.webgl &&
+        renderer instanceof sigma.renderers.webgl ?
+        renderer.camera.prefix :
+        renderer.options.prefix,
       _hoverStack = [],
       _hoverIndex = {},
       _isMouseDown = false,
@@ -66,11 +69,11 @@
     }
 
     // It removes the initial substring ('read_') if it's a WegGL renderer.
-    if (renderer instanceof sigma.renderers.webgl) {
-      _prefix = renderer.options.prefix.substr(5);
-    } else {
-      _prefix = renderer.options.prefix;
-    }
+    // if (renderer instanceof sigma.renderers.webgl) {
+    //   _prefix = renderer.options.prefix.substr(5);
+    // } else {
+    //   _prefix = renderer.options.prefix;
+    // }
 
     renderer.bind('overNode', nodeMouseOver);
     renderer.bind('outNode', treatOutNode);

--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -56,7 +56,7 @@
       _node = null,
       _prefix = sigma.renderers.webgl &&
         renderer instanceof sigma.renderers.webgl ?
-        renderer.camera.prefix :
+        _camera.prefix :
         renderer.options.prefix,
       _hoverStack = [],
       _hoverIndex = {},


### PR DESCRIPTION
In old version,dragNodes Plugins can't work with webgl renderer. Today i found why.
Because the screenX = f(x), x represents the initial x,
screenY = f(y), y represents the initial y.
But in webgl renderer it use cameraX, cameraY.so it dont work.
I solved it,but it already fixed. it can be better. 
In the webgl renderer
`this.camera.applyView(`
       ` undefined,`
        `undefined,`
        `{`
          `nodes: a,`
          `edges: [],`
         ` width: this.width,`
          `height: this.height`
        `}`
      `);`
`sigma.classes.camera.prototype.applyView = function(read, write, options) {`
    `options = options || {};`
    `write = write !== undefined ? write : this.prefix;`
    `read = read !== undefined ? read : this.readPrefix;`
Screen coordinate prefix it should be 'camera.prefix'.it will be better.
My english is poor, hope it can be helpful.