### PR TITLE
Fix #778: label overlapping problem for parallel edges (self-loop edges included)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ build/*
 *.log
 *.swp
 .DS_Store
-.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/*
 *.log
 *.swp
 .DS_Store
+.idea/*

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/examples/parallel-edges.html
+++ b/examples/parallel-edges.html
@@ -76,6 +76,7 @@ var i,
     s,
     N = 2,
     E = 10,
+    L = 3,
     g = {
       nodes: [],
       edges: []
@@ -98,6 +99,18 @@ for (i = 0; i < E; i++)
     label: 'Edge ' + i,
     source: 'n0',
     target: 'n1',
+    size: 1,
+    color: '#ccc',
+    type: 'curvedArrow',
+    count: i
+  });
+
+for (i = 0; i < L; i++)
+  g.edges.push({
+    id: 'e_loop' + i,
+    label: 'Edge_loop ' + i,
+    source: 'n0',
+    target: 'n0',
     size: 1,
     color: '#ccc',
     type: 'curvedArrow',

--- a/examples/parallel-edges.html
+++ b/examples/parallel-edges.html
@@ -51,6 +51,10 @@
 <script src="../plugins/sigma.renderers.parallelEdges/sigma.canvas.edges.curvedArrow.js"></script>
 <script src="../plugins/sigma.renderers.parallelEdges/sigma.canvas.edgehovers.curve.js"></script>
 <script src="../plugins/sigma.renderers.parallelEdges/sigma.canvas.edgehovers.curvedArrow.js"></script>
+<script src="../plugins/sigma.renderers.edgeLabels/settings.js"></script>
+<script src="../plugins/sigma.renderers.edgeLabels/sigma.canvas.edges.labels.def.js"></script>
+<script src="../plugins/sigma.renderers.edgeLabels/sigma.canvas.edges.labels.curve.js"></script>
+<script src="../plugins/sigma.renderers.edgeLabels/sigma.canvas.edges.labels.curvedArrow.js"></script>
 <div id="container">
   <style>
     #graph-container {
@@ -94,7 +98,7 @@ for (i = 0; i < E; i++)
     label: 'Edge ' + i,
     source: 'n0',
     target: 'n1',
-    size: Math.random(),
+    size: 1,
     color: '#ccc',
     type: 'curvedArrow',
     count: i

--- a/plugins/sigma.renderers.edgeLabels/sigma.canvas.edges.labels.curve.js
+++ b/plugins/sigma.renderers.edgeLabels/sigma.canvas.edges.labels.curve.js
@@ -35,6 +35,7 @@
         sY = source[prefix + 'y'],
         tX = target[prefix + 'x'],
         tY = target[prefix + 'y'],
+        count = edge.count || 0,
         dX = tX - sX,
         dY = tY - sY,
         sign = (sX < tX) ? 1 : -1,
@@ -44,13 +45,13 @@
         t = 0.5;  //length of the curve
 
     if (source.id === target.id) {
-      cp = sigma.utils.getSelfLoopControlPoints(sX, sY, sSize);
+      cp = sigma.utils.getSelfLoopControlPoints(sX, sY, sSize, count);
       c = sigma.utils.getPointOnBezierCurve(
         t, sX, sY, tX, tY, cp.x1, cp.y1, cp.x2, cp.y2
       );
       angle = Math.atan2(1, 1); // 45°
     } else {
-      cp = sigma.utils.getQuadraticControlPoint(sX, sY, tX, tY);
+      cp = sigma.utils.getQuadraticControlPoint(sX, sY, tX, tY, count);
       c = sigma.utils.getPointOnQuadraticCurve(t, sX, sY, tX, tY, cp.x, cp.y);
       angle = Math.atan2(dY * sign, dX * sign);
     }


### PR DESCRIPTION
I came into the same problem that mentioned in #778. This overlapping issue is fixed by adding count information to the plugin sigma.canvas.edges.labels.curve.js. The comparison is shown below. 

Also, I modified the example file examples/parallel-edges.html to show the result.

Edges between two nodes:
Before:
<img src="https://user-images.githubusercontent.com/39191297/41505380-e316bdac-723a-11e8-87b1-bb66c501083f.png" width="500">

After:
<img src="https://user-images.githubusercontent.com/39191297/41505460-5030cd64-723c-11e8-8c48-90993adb66f5.png" width="500">

Edges between self-loop nodes:
Before:
<img src="https://user-images.githubusercontent.com/39191297/41505444-204de280-723c-11e8-918f-cef3b97eb50a.png" width="250">

After:
<img src="https://user-images.githubusercontent.com/39191297/41505445-207d894a-723c-11e8-92cc-e99217a76ff7.png" width="250">
