### PR TITLE
Webgl alpha

### DIFF
--- a/src/renderers/sigma.renderers.def.js
+++ b/src/renderers/sigma.renderers.def.js
@@ -14,8 +14,8 @@
     canvas = document.createElement('canvas');
     try {
       webgl = !!(
-        canvas.getContext('webgl') ||
-        canvas.getContext('experimental-webgl')
+        canvas.getContext('webgl', {premultipliedAlpha: false}) ||
+        canvas.getContext('experimental-webgl', {premultipliedAlpha: false})
       );
     } catch (e) {
       webgl = false;

--- a/src/renderers/sigma.renderers.def.js
+++ b/src/renderers/sigma.renderers.def.js
@@ -10,13 +10,15 @@
   // Check if WebGL is enabled:
   var canvas,
       webgl = !!global.WebGLRenderingContext;
+      
   if (webgl) {
     canvas = document.createElement('canvas');
     try {
       webgl = !!(
-        canvas.getContext('webgl', {premultipliedAlpha: false}) ||
-        canvas.getContext('experimental-webgl', {premultipliedAlpha: false})
+        canvas.getContext('webgl') ||
+        canvas.getContext('experimental-webgl')
       );
+      
     } catch (e) {
       webgl = false;
     }

--- a/src/renderers/webgl/sigma.webgl.edges.def.js
+++ b/src/renderers/webgl/sigma.webgl.edges.def.js
@@ -14,7 +14,7 @@
    */
   sigma.webgl.edges.def = {
     POINTS: 6,
-    ATTRIBUTES: 7,
+    ATTRIBUTES: 8,
     addEdge: function(edge, source, target, data, i, prefix, settings) {
       var w = (edge[prefix + 'size'] || 1) / 2,
           x1 = source[prefix + 'x'],
@@ -45,7 +45,8 @@
       data[i++] = y2;
       data[i++] = w;
       data[i++] = 0.0;
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
       
       data[i++] = x2;
       data[i++] = y2;
@@ -53,7 +54,9 @@
       data[i++] = y1;
       data[i++] = w;
       data[i++] = 1.0;
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
+      
       
       data[i++] = x2;
       data[i++] = y2;
@@ -61,7 +64,9 @@
       data[i++] = y1;
       data[i++] = w;
       data[i++] = 0.0;
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
+      
       
       data[i++] = x2;
       data[i++] = y2;
@@ -69,7 +74,9 @@
       data[i++] = y1;
       data[i++] = w;
       data[i++] = 0.0;
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
+      
       
       data[i++] = x1;
       data[i++] = y1;
@@ -77,7 +84,9 @@
       data[i++] = y2;
       data[i++] = w;
       data[i++] = 1.0;
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
+      
       
       data[i++] = x1;
       data[i++] = y1;
@@ -85,7 +94,9 @@
       data[i++] = y2;
       data[i++] = w;
       data[i++] = 0.0;
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
+      
       
     },
     render: function(gl, program, data, params) {
@@ -172,7 +183,7 @@
         20
       );
       gl.vertexAttribPointer(colorLocation,
-        1,
+        2,
         gl.FLOAT,
         false,
         this.ATTRIBUTES * Float32Array.BYTES_PER_ELEMENT,
@@ -197,7 +208,7 @@
           'attribute vec2 a_position2;',
           'attribute float a_thickness;',
           'attribute float a_minus;',
-          'attribute float a_color;',
+          'attribute vec2 a_color;',
 
           'uniform vec2 u_resolution;',
           'uniform float u_ratio;',
@@ -227,11 +238,11 @@
             ');',
 
             // Extract the color:
-            'float c = a_color;',
+            'float c = a_color.x;',
             'color.b = mod(c, 256.0); c = floor(c / 256.0);',
             'color.g = mod(c, 256.0); c = floor(c / 256.0);',
-            'color.r = mod(c, 256.0); c = floor(c / 256.0); color /= 255.0;',
-            'color.a = 1.0; ',
+            'color.r = mod(c, 256.0); color /= 255.0;',
+            'color.a = a_color.y;',
           '}'
         ].join('\n'),
         gl.VERTEX_SHADER

--- a/src/renderers/webgl/sigma.webgl.edges.def.js
+++ b/src/renderers/webgl/sigma.webgl.edges.def.js
@@ -90,7 +90,7 @@
     },
     render: function(gl, program, data, params) {
       var buffer;
-
+      
       // Define attributes:
       var colorLocation =
             gl.getAttribLocation(program, 'a_color'),
@@ -172,10 +172,10 @@
         20
       );
       gl.vertexAttribPointer(colorLocation,
-        4,
-        gl.UNSIGNED_BYTE,
-        true,
-        this.ATTRIBUTES * Uint8Array.BYTES_PER_ELEMENT * 4,
+        1,
+        gl.FLOAT,
+        false,
+        this.ATTRIBUTES * Float32Array.BYTES_PER_ELEMENT,
         24
       );
 
@@ -197,7 +197,7 @@
           'attribute vec2 a_position2;',
           'attribute float a_thickness;',
           'attribute float a_minus;',
-          'attribute vec4 a_color;',
+          'attribute float a_color;',
 
           'uniform vec2 u_resolution;',
           'uniform float u_ratio;',
@@ -227,7 +227,11 @@
             ');',
 
             // Extract the color:
-            'color = a_color;',
+            'float c = a_color;',
+            'color.b = mod(c, 256.0); c = floor(c / 256.0);',
+            'color.g = mod(c, 256.0); c = floor(c / 256.0);',
+            'color.r = mod(c, 256.0); c = floor(c / 256.0); color /= 255.0;',
+            'color.a = 1.0; ',
           '}'
         ].join('\n'),
         gl.VERTEX_SHADER

--- a/src/renderers/webgl/sigma.webgl.edges.def.js
+++ b/src/renderers/webgl/sigma.webgl.edges.def.js
@@ -37,7 +37,7 @@
         }
 
       // Normalize color:
-      color = sigma.utils.floatColor(color);
+      color = sigma.utils.intColor(color);
 
       data[i++] = x1;
       data[i++] = y1;
@@ -46,7 +46,7 @@
       data[i++] = w;
       data[i++] = 0.0;
       data[i++] = color;
-
+      
       data[i++] = x2;
       data[i++] = y2;
       data[i++] = x1;
@@ -54,7 +54,7 @@
       data[i++] = w;
       data[i++] = 1.0;
       data[i++] = color;
-
+      
       data[i++] = x2;
       data[i++] = y2;
       data[i++] = x1;
@@ -62,7 +62,7 @@
       data[i++] = w;
       data[i++] = 0.0;
       data[i++] = color;
-
+      
       data[i++] = x2;
       data[i++] = y2;
       data[i++] = x1;
@@ -70,7 +70,7 @@
       data[i++] = w;
       data[i++] = 0.0;
       data[i++] = color;
-
+      
       data[i++] = x1;
       data[i++] = y1;
       data[i++] = x2;
@@ -78,7 +78,7 @@
       data[i++] = w;
       data[i++] = 1.0;
       data[i++] = color;
-
+      
       data[i++] = x1;
       data[i++] = y1;
       data[i++] = x2;
@@ -86,6 +86,7 @@
       data[i++] = w;
       data[i++] = 0.0;
       data[i++] = color;
+      
     },
     render: function(gl, program, data, params) {
       var buffer;
@@ -171,10 +172,10 @@
         20
       );
       gl.vertexAttribPointer(colorLocation,
-        1,
-        gl.FLOAT,
-        false,
-        this.ATTRIBUTES * Float32Array.BYTES_PER_ELEMENT,
+        4,
+        gl.UNSIGNED_BYTE,
+        true,
+        this.ATTRIBUTES * Uint8Array.BYTES_PER_ELEMENT * 4,
         24
       );
 
@@ -196,7 +197,7 @@
           'attribute vec2 a_position2;',
           'attribute float a_thickness;',
           'attribute float a_minus;',
-          'attribute float a_color;',
+          'attribute vec4 a_color;',
 
           'uniform vec2 u_resolution;',
           'uniform float u_ratio;',
@@ -226,11 +227,7 @@
             ');',
 
             // Extract the color:
-            'float c = a_color;',
-            'color.b = mod(c, 256.0); c = floor(c / 256.0);',
-            'color.g = mod(c, 256.0); c = floor(c / 256.0);',
-            'color.r = mod(c, 256.0); c = floor(c / 256.0); color /= 255.0;',
-            'color.a = 1.0;',
+            'color = a_color;',
           '}'
         ].join('\n'),
         gl.VERTEX_SHADER

--- a/src/renderers/webgl/sigma.webgl.nodes.def.js
+++ b/src/renderers/webgl/sigma.webgl.nodes.def.js
@@ -16,28 +16,31 @@
    */
   sigma.webgl.nodes.def = {
     POINTS: 3,
-    ATTRIBUTES: 5,
+    ATTRIBUTES: 6,
     addNode: function(node, data, i, prefix, settings) {
-      var color = sigma.utils.floatColor(
+      var color = sigma.utils.intColor(
         node.color || settings('defaultNodeColor')
       );
 
       data[i++] = node[prefix + 'x'];
       data[i++] = node[prefix + 'y'];
       data[i++] = node[prefix + 'size'];
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
       data[i++] = 0;
 
       data[i++] = node[prefix + 'x'];
       data[i++] = node[prefix + 'y'];
       data[i++] = node[prefix + 'size'];
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
       data[i++] = 2 * Math.PI / 3;
 
       data[i++] = node[prefix + 'x'];
       data[i++] = node[prefix + 'y'];
       data[i++] = node[prefix + 'size'];
-      data[i++] = color;
+      data[i++] = color[0];
+      data[i++] = color[1];
       data[i++] = 4 * Math.PI / 3;
     },
     render: function(gl, program, data, params) {
@@ -96,7 +99,7 @@
       );
       gl.vertexAttribPointer(
         colorLocation,
-        1,
+        2,
         gl.FLOAT,
         false,
         this.ATTRIBUTES * Float32Array.BYTES_PER_ELEMENT,
@@ -108,7 +111,7 @@
         gl.FLOAT,
         false,
         this.ATTRIBUTES * Float32Array.BYTES_PER_ELEMENT,
-        16
+        20
       );
 
       gl.drawArrays(
@@ -127,7 +130,7 @@
         [
           'attribute vec2 a_position;',
           'attribute float a_size;',
-          'attribute float a_color;',
+          'attribute vec2 a_color;',
           'attribute float a_angle;',
 
           'uniform vec2 u_resolution;',
@@ -158,11 +161,11 @@
             'gl_Position = vec4(position, 0, 1);',
 
             // Extract the color:
-            'float c = a_color;',
+            'float c = a_color.x;',
             'color.b = mod(c, 256.0); c = floor(c / 256.0);',
             'color.g = mod(c, 256.0); c = floor(c / 256.0);',
-            'color.r = mod(c, 256.0); c = floor(c / 256.0); color /= 255.0;',
-            'color.a = 1.0;',
+            'color.r = mod(c, 256.0); color /= 255.0;',
+            'color.a = a_color.y;',
           '}'
         ].join('\n'),
         gl.VERTEX_SHADER

--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -157,7 +157,7 @@
         b = +val[3];
         if (val[4] !== undefined) a = +val[4];
     }
-    var color = color = (
+    var color = (
       a * 256 * 256 * 256 +
       r * 256 * 256 +
       g * 256 +

--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -113,6 +113,63 @@
     };
   })();
 
+  
+  var intColorCache = {};
+  sigma.utils.intColor = function(val) {
+      if (intColorCache[val])
+          return intColorCache[val];
+      
+      var original = val,
+          r = 0,
+          g = 0,
+          b = 0,
+          a = 255; // default to fully opaque
+      if (val[0] === '#') {
+        val = val.slice(1);
+        if (val.length === 3) { // format #rgb
+            r = parseInt(val.charAt(0) + val.charAt(0), 16);
+            g = parseInt(val.charAt(1) + val.charAt(1), 16);
+            b = parseInt(val.charAt(2) + val.charAt(2), 16);
+        }
+        else if (val.length === 4) { // format #rgba
+            r = parseInt(val.charAt(0) + val.charAt(0), 16);
+            g = parseInt(val.charAt(1) + val.charAt(1), 16);
+            b = parseInt(val.charAt(2) + val.charAt(2), 16);
+            a = parseInt(val.charAt(3) + val.charAt(3), 16);
+        }
+        else if (val.length === 6) { // format #rrggbb
+            r = parseInt(val.charAt(0) + val.charAt(1), 16);
+            g = parseInt(val.charAt(2) + val.charAt(3), 16);
+            b = parseInt(val.charAt(4) + val.charAt(5), 16);
+        }
+        else { // format #rrggbbaa
+            r = parseInt(val.charAt(0) + val.charAt(1), 16);
+            g = parseInt(val.charAt(2) + val.charAt(3), 16);
+            b = parseInt(val.charAt(4) + val.charAt(5), 16);
+            a = parseInt(val.charAt(6) + val.charAt(7), 16);
+        }
+      } else if (val.match(/^ *rgba? *\(/)) {
+        val = val.match(
+            /^\s*rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*(\d+))?\s*\)\s*$/
+        );
+        r = +val[1];
+        g = +val[2];
+        b = +val[3];
+        if (val[4] !== undefined) a = +val[4];
+    }
+    var color = color = (
+      a * 256 * 256 * 256 +
+      r * 256 * 256 +
+      g * 256 +
+      b
+    );
+
+    // Caching the color
+    intColorCache[original] = color;
+
+    return color;
+  }
+  
   /**
    * This function takes an hexa color (for instance "#ffcc00" or "#fc0") or a
    * rgb / rgba color (like "rgb(255,255,12)" or "rgba(255,255,12,1)") and

--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -123,7 +123,7 @@
           r = 0,
           g = 0,
           b = 0,
-          a = 255; // default to fully opaque
+          a = 1.0; // default to fully opaque, adopt 'canvas' conventions
       if (val[0] === '#') {
         val = val.slice(1);
         if (val.length === 3) { // format #rgb
@@ -150,19 +150,15 @@
         }
       } else if (val.match(/^ *rgba? *\(/)) {
         val = val.match(
-            /^\s*rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*(\d+))?\s*\)\s*$/
+            /^\s*rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*(\d*\.?\d*))?\s*\)\s*$/
         );
         r = +val[1];
         g = +val[2];
         b = +val[3];
         if (val[4] !== undefined) a = +val[4];
     }
-    var color = (
-      a * 256 * 256 * 256 +
-      r * 256 * 256 +
-      g * 256 +
-      b
-    );
+    var color = [r*256*256 + g*256 + b, a];
+      
 
     // Caching the color
     intColorCache[original] = color;

--- a/test/unit.utils.js
+++ b/test/unit.utils.js
@@ -32,19 +32,21 @@ test('Int color', function() {
     '#D1D1D1',
     '#d1d1d1',
     'rgb(234, 245, 218)',// EA F5 DA
-    'rgba(234, 245, 218, 25)' // ... 19
+    'rgba(234, 245, 218, 25)', // ... 19
+    'rgba(234, 245, 218, .1)' // ... 19
     
   ];
 
   var outputs = [
-    4294967040,
-    4291940817,
-    4291940817,
-    4293588442,
-    434828762
+    [16776960, 1],
+    [13750737, 1],
+    [13750737, 1],
+    [15398362, 1],
+    [15398362, 25],
+    [15398362, 0.1],
   ];
 
   inputs.forEach(function(input, i) {
-    strictEqual(intColor(input), outputs[i]);
+    deepEqual(intColor(input), outputs[i]);
   });
 });

--- a/test/unit.utils.js
+++ b/test/unit.utils.js
@@ -24,3 +24,27 @@ test('Float color', function() {
     strictEqual(floatColor(input), outputs[i]);
   });
 });
+test('Int color', function() {
+  var intColor = sigma.utils.intColor;
+
+  var inputs = [
+    '#FF0',
+    '#D1D1D1',
+    '#d1d1d1',
+    'rgb(234, 245, 218)',// EA F5 DA
+    'rgba(234, 245, 218, 25)' // ... 19
+    
+  ];
+
+  var outputs = [
+    4294967040,
+    4291940817,
+    4291940817,
+    4293588442,
+    434828762
+  ];
+
+  inputs.forEach(function(input, i) {
+    strictEqual(intColor(input), outputs[i]);
+  });
+});


### PR DESCRIPTION
This is an attempt at enabling transparency for nodes and edges in the WebGL renderer. It aims at having a result similar to the one achieved in canvas when passing an 'rgba' color. 
I still observe differences wrt. canvas renderer (linked to background color apparently) but this is usable.
Comments welcome :) 