### PR TITLE
add        maxBoundaries = settings('maxBoundaries') || bounds,      …

### DIFF
--- a/src/middlewares/sigma.middlewares.rescale.js
+++ b/src/middlewares/sigma.middlewares.rescale.js
@@ -36,10 +36,8 @@
           readPrefix,
           true
         ),
-        minX = bounds.minX,
-        minY = bounds.minY,
-        maxX = bounds.maxX,
-        maxY = bounds.maxY,
+        maxBoundaries = settings('maxBoundaries') || bounds,
+        {minX ,minY, maxX, maxY} = maxBoundaries,
         sizeMax = bounds.sizeMax,
         weightMax = bounds.weightMax,
         w = settings('width') || 1,


### PR DESCRIPTION
fixes Issue #687  #613  and might fix other related issues.

allows the developer to input maxBoundaries to settings which will make sure  autoScale wont go crazy when you have nodes at distance.