### PR TITLE
Update sigma.canvas.edgehovers.arrow.js (fix "minArrowSize")

### DIFF
--- a/src/renderers/canvas/sigma.canvas.edgehovers.arrow.js
+++ b/src/renderers/canvas/sigma.canvas.edgehovers.arrow.js
@@ -28,7 +28,7 @@
 
     size = (edge.hover) ?
       settings('edgeHoverSizeRatio') * size : size;
-    var aSize = size * 2.5,
+    var aSize = Math.max(size * 2.5, settings('minArrowSize')),
         d = Math.sqrt(Math.pow(tX - sX, 2) + Math.pow(tY - sY, 2)),
         aX = sX + (tX - sX) * (d - aSize - tSize) / d,
         aY = sY + (tY - sY) * (d - aSize - tSize) / d,


### PR DESCRIPTION
If we change `minArrowSize` in settings, and the size of arrow is small, that will be this:
https://imgur.com/a/rsBvUo8