### PR TITLE
Add non-nullable modifier to return type of functions never returning null

### DIFF
--- a/src/utils/sigma.utils.js
+++ b/src/utils/sigma.utils.js
@@ -58,7 +58,7 @@
   /**
    * A short "Date.now()" polyfill.
    *
-   * @return {Number} The current time (in ms).
+   * @return {number} The current time (in ms).
    */
   sigma.utils.dateNow = function() {
     return Date.now ? Date.now() : new Date().getTime();


### PR DESCRIPTION
Alternatively, use a primitive type instead of nullable boxed type.