### PR TITLE
V2 issue 1132

### DIFF
--- a/examples/hide-edges-on-move.ts
+++ b/examples/hide-edges-on-move.ts
@@ -1,0 +1,24 @@
+import { UndirectedGraph } from "graphology";
+import erdosRenyi from "graphology-generators/random/erdos-renyi";
+import randomLayout from "graphology-layout/random";
+import chroma from "chroma-js";
+
+import { getRandomName, globalize } from "./utils";
+import Sigma from "../src/sigma";
+
+const container = document.getElementById("container");
+
+const graph = erdosRenyi(UndirectedGraph, { order: 100, probability: 0.2 });
+randomLayout.assign(graph);
+
+graph.nodes().forEach((node) => {
+  graph.mergeNodeAttributes(node, {
+    label: getRandomName(),
+    size: Math.max(4, Math.random() * 10),
+    color: chroma.random().hex(),
+  });
+});
+
+const renderer = new Sigma(graph, container, { hideEdgesOnMove: true });
+
+globalize({ graph, renderer });

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -32,6 +32,10 @@ const EXAMPLES = {
     id: "gexf",
     title: "GEXF",
   },
+  hideEdgesOnMove: {
+    id: "hide-edges-on-move",
+    title: "Hide edges on move",
+  },
   layout: {
     id: "layout",
     title: "Force Atlas 2 Layout",
@@ -132,6 +136,7 @@ module.exports = {
     },
   },
   devServer: {
+    host: "0.0.0.0",
     port: 8000,
   },
 };

--- a/src/core/captors/mouse.ts
+++ b/src/core/captors/mouse.ts
@@ -177,11 +177,13 @@ export default class MouseCaptor extends Captor {
           easing: "quadraticOut",
         },
       );
-    } else if (this.lastMouseX !== x || this.lastMouseY !== y) {
-      camera.setState({
-        x: cameraState.x,
-        y: cameraState.y,
-      });
+    } else {
+      if (this.lastMouseX !== x || this.lastMouseY !== y) {
+        camera.setState({
+          x: cameraState.x,
+          y: cameraState.y,
+        });
+      }
     }
 
     this.isMoving = false;
@@ -192,7 +194,6 @@ export default class MouseCaptor extends Captor {
   handleMove(e: MouseEvent): void | boolean {
     if (!this.enabled) return;
     this.emit("mousemove", getMouseCoords(e));
-
     if (this.isMouseDown) {
       // TODO: dispatch events
       this.isMoving = true;
@@ -203,8 +204,7 @@ export default class MouseCaptor extends Captor {
       }
 
       this.movingTimeout = window.setTimeout(() => {
-        this.movingTimeout = null;
-        this.isMoving = false;
+        this.handleDown(e);
       }, DRAG_TIMEOUT);
 
       const camera = this.renderer.getCamera();


### PR DESCRIPTION
@Yomguithereal  Can you do a reviewof this code please ?

The root cause of #1132 is that when the timeout on handleMove is executed, the state of the captor is not correct, specially when you drag the graph outside the container (see draggedEvents). 

What I did is to call the handleUp function (normally it's the ending function of the handleMove, right ?).

With this fix there are two side-effects : 
* when you drag the graph and stay at the same position (but still with the mouse down), edges are displayed 
* the event mouseup is fired 

FYI, I have configured webpack to listen on the network. With that setting, I can run the examples and test them with my smartphone.