### PR TITLE
Fixed the loading of node images from remote url

### DIFF
--- a/src/rendering/webgl/programs/node.image.ts
+++ b/src/rendering/webgl/programs/node.image.ts
@@ -61,6 +61,7 @@ export default function getNodeProgramImage() {
     images[imageSource] = { status: "loading" };
 
     // Load image:
+    image.setAttribute('crossOrigin', '');
     image.src = imageSource;
   }
 


### PR DESCRIPTION
Setting the cross orgin attribute in loadImage function

## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

> The node images from remote url giving the error **the canvas has been tainted by cross-origin data**

## What is the new behavior?

> Now the node images will be loaded from remote urls

## Other information

>  Added the crossOrigin attribute to the image attribute in loadImage function
