### PR TITLE
fix for issue #1157

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -435,21 +435,8 @@ export default class Sigma extends EventEmitter {
     // Handling click
     const createClickListener = (eventType: string): ((e: MouseCoords) => void) => {
       return (e) => {
-        const quadNodes = getQuadNodes(e.x, e.y);
-
-        for (let i = 0, l = quadNodes.length; i < l; i++) {
-          const node = quadNodes[i];
-
-          const data = this.nodeDataCache[node];
-
-          const pos = this.framedGraphToViewport(data);
-
-          const size = this.scaleSize(data.size);
-
-          if (mouseIsOnNode(e.x, e.y, pos.x, pos.y, size))
-            return this.emit(`${eventType}Node`, { node, captor: e, event: e });
-        }
-
+        if (this.hoveredNode)
+            return this.emit(`${eventType}Node`, { node: this.hoveredNode, captor: e, event: e });
         return this.emit(`${eventType}Stage`, { event: e });
       };
     };


### PR DESCRIPTION
## Pull request type
Bugfix: Issue number #1157

## Current Behavior
Node clicks do not match the hovered node

## New Bahvior
Node clicks always emit the currently hovered node.

## Notes
This my implementation of proposed solution no. 1 from issue #1157. All that I did was remove the selection algorithm in the node click handler and instead just emitted the currently hovered node. If no node is currently hovered, it emits a stage click event. The hover selection algorithm remains unchanged. Note that this does not address any of the discussion regarding zIndex.

