### PR TITLE
allow MouseCoords to preventDefault()

### DIFF
--- a/src/core/captors/captor.ts
+++ b/src/core/captors/captor.ts
@@ -81,9 +81,8 @@ export function getMouseCoords(e: MouseEvent): MouseCoords {
     metaKey: e.metaKey,
     altKey: e.altKey,
     shiftKey: e.shiftKey,
-
-    // TODO: this is not ideal... But I am wondering why we don't just pass the event through
-    preventDefault: e.preventDefault.bind(e),
+    defaultPrevented: false,
+    preventDefault(): void {this.defaultPrevented = true},
     original: e,
   };
 }

--- a/src/core/captors/mouse.ts
+++ b/src/core/captors/mouse.ts
@@ -112,6 +112,17 @@ export default class MouseCaptor extends Captor {
   handleDoubleClick(e: MouseEvent): void | boolean {
     if (!this.enabled) return;
 
+    if (e.preventDefault) e.preventDefault();
+    else e.returnValue = false;
+    e.stopPropagation();
+
+    const mouseCoords = getMouseCoords(e)
+    this.emit("doubleClick", mouseCoords);
+
+    if (mouseCoords.defaultPrevented)
+        return false
+
+    // default behavior
     const camera = this.renderer.getCamera();
     const newRatio = camera.getState().ratio / DOUBLE_CLICK_ZOOMING_RATIO;
 
@@ -120,12 +131,6 @@ export default class MouseCaptor extends Captor {
       duration: DOUBLE_CLICK_ZOOMING_DURATION,
     });
 
-    if (e.preventDefault) e.preventDefault();
-    else e.returnValue = false;
-
-    e.stopPropagation();
-
-    this.emit("doubleClick", getMouseCoords(e));
 
     return false;
   }
@@ -257,6 +262,13 @@ export default class MouseCaptor extends Captor {
 
     if (!delta) return false;
 
+    const wheelCoords = getWheelCoords(e)
+    this.emit("wheel", wheelCoords);
+
+    if (wheelCoords.defaultPrevented)
+        return false
+
+    // default behavior
     const ratioDiff = delta > 0 ? 1 / ZOOMING_RATIO : ZOOMING_RATIO;
     const camera = this.renderer.getCamera();
     const newRatio = camera.getState().ratio * ratioDiff;
@@ -285,8 +297,6 @@ export default class MouseCaptor extends Captor {
 
     this.currentWheelDirection = wheelDirection;
     this.lastWheelTriggerTime = now;
-
-    this.emit("wheel", getWheelCoords(e));
 
     return false;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface MouseCoords extends Coordinates {
   metaKey: boolean;
   altKey: boolean;
   shiftKey: boolean;
+  defaultPrevented: boolean;
   preventDefault(): void;
   original: MouseEvent;
 }


### PR DESCRIPTION
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
As mentioned in [this comment](https://github.com/jacomyal/sigma.js/issues/1153#issuecomment-976841566) of issue #1153, the new doubleClick and wheel events cannot cancel the default zooming behavior.

## What is the new behavior?
doubleClick and wheel event can now cancel their default behavior by calling event.preventDefault() on the passed MouseCoords or WheelCoords event object.

## Description
This is accomplished by adding a boolean defaultPrevented property to the MouseCoords (and thus WheelCoords) event. This allows any handler which uses these events to conditionally add default behavior that can be cancelled. The defaultPrevented property can also be set using the associated preventDefault() method.

I noticed that MouseCoords.preventDefault() was bound to MouseEvent.preventDefault(), which seemed redundant given that the MouseEvent is already accessible in MouseCoords.original ([here](https://github.com/jacomyal/sigma.js/blob/443ee9f1f4485370d1e56b31878a6800b3399a9e/src/core/captors/captor.ts#L85-L87)). I realized that using this to instead set an independent flag in the MouseCoords could implement the desired behavior. If this is an error on my part, please let me know.

Also, to address the [TODO in the getMouseCoords](https://github.com/jacomyal/sigma.js/blob/443ee9f1f4485370d1e56b31878a6800b3399a9e/src/core/captors/captor.ts#L85), not passing the event through is what allowed this to work, because then we can have separate defaultPrevented flags for the MouseCoords and MouseEvent that can be set independently.
