### PR TITLE
Adding useful declaration for events

### DIFF
--- a/examples/events/index.ts
+++ b/examples/events/index.ts
@@ -46,12 +46,11 @@ const renderer = new Sigma(graph, container, {
   },
 });
 
-(["enterNode", "leaveNode", "clickNode", "rightClickNode", "doubleClickNode", "wheelNode"] as const).forEach(
-  (eventType) => renderer.on(eventType, ({ node }) => logEvent(eventType, "node", node)),
-);
-(["clickEdge", "rightClickEdge", "doubleClickEdge", "wheelEdge"] as const).forEach((eventType) =>
-  renderer.on(eventType, ({ edge }) => logEvent(eventType, "edge", edge)),
-);
+const nodeEvents = ["enterNode", "leaveNode", "clickNode", "rightClickNode", "doubleClickNode", "wheelNode"] as const;
+const edgeEvents = ["clickEdge", "rightClickEdge", "doubleClickEdge", "wheelEdge"] as const;
+
+nodeEvents.forEach((eventType) => renderer.on(eventType, ({ node }) => logEvent(eventType, "node", node)));
+edgeEvents.forEach((eventType) => renderer.on(eventType, ({ edge }) => logEvent(eventType, "edge", edge)));
 renderer.on("enterEdge", ({ edge }) => {
   logEvent("enterEdge", "edge", edge);
   hoveredEdge = edge;

--- a/examples/events/index.ts
+++ b/examples/events/index.ts
@@ -46,10 +46,10 @@ const renderer = new Sigma(graph, container, {
   },
 });
 
-["enterNode", "leaveNode", "clickNode", "rightClickNode", "doubleClickNode", "wheelNode"].forEach((eventType) =>
-  renderer.on(eventType, ({ node }) => logEvent(eventType, "node", node)),
+(["enterNode", "leaveNode", "clickNode", "rightClickNode", "doubleClickNode", "wheelNode"] as const).forEach(
+  (eventType) => renderer.on(eventType, ({ node }) => logEvent(eventType, "node", node)),
 );
-["clickEdge", "rightClickEdge", "doubleClickEdge", "wheelEdge"].forEach((eventType) =>
+(["clickEdge", "rightClickEdge", "doubleClickEdge", "wheelEdge"] as const).forEach((eventType) =>
   renderer.on(eventType, ({ edge }) => logEvent(eventType, "edge", edge)),
 );
 renderer.on("enterEdge", ({ edge }) => {

--- a/src/core/camera.ts
+++ b/src/core/camera.ts
@@ -5,8 +5,6 @@
  * Class designed to store camera information & used to update it.
  * @module
  */
-import { EventEmitter } from "events";
-
 import { ANIMATE_DEFAULTS, AnimateOptions } from "../utils/animate";
 import easings from "../utils/easings";
 import { cancelFrame, requestFrame } from "../utils";
@@ -29,10 +27,7 @@ type CameraEvents = {
  *
  * @constructor
  */
-export default class Camera
-  extends (EventEmitter as unknown as new () => TypedEventEmitter<CameraEvents>)
-  implements CameraState
-{
+export default class Camera extends TypedEventEmitter<CameraEvents> implements CameraState {
   x = 0.5;
   y = 0.5;
   angle = 0;
@@ -46,7 +41,6 @@ export default class Camera
 
   constructor() {
     super();
-    this.rawEmitter = this as EventEmitter;
 
     // State
     this.previousState = this.getState();

--- a/src/core/camera.ts
+++ b/src/core/camera.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from "events";
 import { ANIMATE_DEFAULTS, AnimateOptions } from "../utils/animate";
 import easings from "../utils/easings";
 import { cancelFrame, requestFrame } from "../utils";
-import { CameraState } from "../types";
+import { CameraState, TypedEventEmitter } from "../types";
 
 /**
  * Defaults.
@@ -18,11 +18,21 @@ import { CameraState } from "../types";
 const DEFAULT_ZOOMING_RATIO = 1.5;
 
 /**
+ * Event types.
+ */
+type CameraEvents = {
+  updated(state: CameraState): void;
+};
+
+/**
  * Camera class
  *
  * @constructor
  */
-export default class Camera extends EventEmitter implements CameraState {
+export default class Camera
+  extends (EventEmitter as unknown as new () => TypedEventEmitter<CameraEvents>)
+  implements CameraState
+{
   x = 0.5;
   y = 0.5;
   angle = 0;
@@ -36,6 +46,7 @@ export default class Camera extends EventEmitter implements CameraState {
 
   constructor() {
     super();
+    this.rawEmitter = this as EventEmitter;
 
     // State
     this.previousState = this.getState();

--- a/src/core/captors/captor.ts
+++ b/src/core/captors/captor.ts
@@ -4,7 +4,7 @@
  * @module
  */
 import { EventEmitter } from "events";
-import { Coordinates, MouseCoords, TouchCoords, WheelCoords } from "../../types";
+import { Coordinates, MouseCoords, TouchCoords, WheelCoords, TypedEventEmitter, Listener } from "../../types";
 import Sigma from "../../sigma";
 
 /**
@@ -145,12 +145,17 @@ export function getWheelDelta(e: WheelEvent): number {
 /**
  * Abstract class representing a captor like the user's mouse or touch controls.
  */
-export default abstract class Captor extends EventEmitter {
+export default abstract class Captor<Events extends Record<string, Listener>> extends (EventEmitter as unknown as {
+  new <T extends Record<string, Listener>>(): TypedEventEmitter<T>;
+})<Events> {
   container: HTMLElement;
   renderer: Sigma;
 
   constructor(container: HTMLElement, renderer: Sigma) {
     super();
+
+    this.rawEmitter = this as EventEmitter;
+
     // Properties
     this.container = container;
     this.renderer = renderer;

--- a/src/core/captors/captor.ts
+++ b/src/core/captors/captor.ts
@@ -3,8 +3,7 @@
  * ======================
  * @module
  */
-import { EventEmitter } from "events";
-import { Coordinates, MouseCoords, TouchCoords, WheelCoords, TypedEventEmitter, Listener } from "../../types";
+import { Coordinates, MouseCoords, TouchCoords, WheelCoords, TypedEventEmitter, EventsMapping } from "../../types";
 import Sigma from "../../sigma";
 
 /**
@@ -145,16 +144,12 @@ export function getWheelDelta(e: WheelEvent): number {
 /**
  * Abstract class representing a captor like the user's mouse or touch controls.
  */
-export default abstract class Captor<Events extends Record<string, Listener>> extends (EventEmitter as unknown as {
-  new <T extends Record<string, Listener>>(): TypedEventEmitter<T>;
-})<Events> {
+export default abstract class Captor<Events extends EventsMapping> extends TypedEventEmitter<Events> {
   container: HTMLElement;
   renderer: Sigma;
 
   constructor(container: HTMLElement, renderer: Sigma) {
     super();
-
-    this.rawEmitter = this as EventEmitter;
 
     // Properties
     this.container = container;

--- a/src/core/captors/mouse.ts
+++ b/src/core/captors/mouse.ts
@@ -5,7 +5,7 @@
  * Sigma's captor dealing with the user's mouse.
  * @module
  */
-import { CameraState } from "../../types";
+import { CameraState, MouseCoords, WheelCoords } from "../../types";
 import Sigma from "../../sigma";
 import Captor, { getWheelDelta, getMouseCoords, getPosition, getWheelCoords } from "./captor";
 
@@ -23,11 +23,24 @@ const DOUBLE_CLICK_ZOOMING_RATIO = 2.2;
 const DOUBLE_CLICK_ZOOMING_DURATION = 200;
 
 /**
+ * Event types.
+ */
+type MouseCaptorEvents = {
+  click(coordinates: MouseCoords): void;
+  rightClick(coordinates: MouseCoords): void;
+  doubleClick(coordinates: MouseCoords): void;
+  mouseup(coordinates: MouseCoords): void;
+  mousedown(coordinates: MouseCoords): void;
+  mousemove(coordinates: MouseCoords): void;
+  wheel(coordinates: WheelCoords): void;
+};
+
+/**
  * Mouse captor class.
  *
  * @constructor
  */
-export default class MouseCaptor extends Captor {
+export default class MouseCaptor extends Captor<MouseCaptorEvents> {
   // State
   enabled = true;
   draggedEvents = 0;

--- a/src/core/captors/touch.ts
+++ b/src/core/captors/touch.ts
@@ -5,7 +5,7 @@
  * Sigma's captor dealing with touch.
  * @module
  */
-import { CameraState, Coordinates, Dimensions } from "../../types";
+import { CameraState, Coordinates, Dimensions, TouchCoords } from "../../types";
 import Captor, { getPosition, getTouchCoords, getTouchesArray } from "./captor";
 import Sigma from "../../sigma";
 
@@ -14,11 +14,20 @@ const TOUCH_INERTIA_RATIO = 3;
 const TOUCH_INERTIA_DURATION = 200;
 
 /**
+ * Event types.
+ */
+type TouchCaptorEvents = {
+  touchdown(coordinates: TouchCoords): void;
+  touchup(coordinates: TouchCoords): void;
+  touchmove(coordinates: TouchCoords): void;
+};
+
+/**
  * Touch captor class.
  *
  * @constructor
  */
-export default class TouchCaptor extends Captor {
+export default class TouchCaptor extends Captor<TouchCaptorEvents> {
   enabled = true;
   isMoving = false;
   startCameraState?: CameraState;

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -3,6 +3,7 @@
  * ========
  * @module
  */
+import { EventEmitter } from "events";
 import graphExtent from "graphology-metrics/extent";
 import Graph from "graphology";
 
@@ -148,7 +149,7 @@ type SigmaEvents = {
  * @param {HTMLElement} container - DOM container in which to render.
  * @param {object}      settings  - Optional settings.
  */
-export default class Sigma extends TypedEventEmitter<SigmaEvents> {
+export default class Sigma extends (EventEmitter as unknown as new () => TypedEventEmitter<SigmaEvents>) {
   private settings: Settings;
   private graph: Graph;
   private mouseCaptor: MouseCaptor;

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -3,7 +3,6 @@
  * ========
  * @module
  */
-import { EventEmitter } from "events";
 import graphExtent from "graphology-metrics/extent";
 import Graph from "graphology";
 
@@ -148,7 +147,7 @@ type SigmaEvents = SigmaStageEvents & SigmaNodeEvents & SigmaEdgeEvents & SigmaA
  * @param {HTMLElement} container - DOM container in which to render.
  * @param {object}      settings  - Optional settings.
  */
-export default class Sigma extends (EventEmitter as unknown as new () => TypedEventEmitter<SigmaEvents>) {
+export default class Sigma extends TypedEventEmitter<SigmaEvents> {
   private settings: Settings;
   private graph: Graph;
   private mouseCaptor: MouseCaptor;
@@ -204,7 +203,6 @@ export default class Sigma extends (EventEmitter as unknown as new () => TypedEv
     super();
 
     this.settings = assign<Settings>({}, DEFAULT_SETTINGS, settings);
-    this.rawEmitter = this as EventEmitter;
 
     // Validating
     validateSettings(this.settings);

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -21,6 +21,7 @@ import {
   NodeDisplayData,
   PlainObject,
   TypedEventEmitter,
+  MouseInteraction,
 } from "./types";
 import {
   createElement,
@@ -103,43 +104,41 @@ interface SigmaEvent {
   preventSigmaDefault(): void;
 }
 
-interface SigmaStageEvent extends SigmaEvent {}
-
-interface SigmaNodeEvent extends SigmaEvent {
+interface SigmaStageEventPayload extends SigmaEvent {}
+interface SigmaNodeEventPayload extends SigmaEvent {
   node: string;
 }
-
-interface SigmaEdgeEvent extends SigmaEvent {
+interface SigmaEdgeEventPayload extends SigmaEvent {
   edge: string;
 }
 
-type SigmaEvents = {
+type SigmaStageEvents = {
+  [E in MouseInteraction as `${E}Stage`]: (payload: SigmaStageEventPayload) => void;
+};
+
+type SigmaNodeEvents = {
+  [E in MouseInteraction as `${E}Node`]: (payload: SigmaNodeEventPayload) => void;
+};
+
+type SigmaEdgeEvents = {
+  [E in MouseInteraction as `${E}Edge`]: (payload: SigmaEdgeEventPayload) => void;
+};
+
+type SigmaAdditionalEvents = {
   // Lifecycle events
   afterRender(): void;
   kill(): void;
 
-  // Stage events
-  clickStage(payload: SigmaStageEvent): void;
-  rightClickStage(payload: SigmaStageEvent): void;
-  doubleClickStage(payload: SigmaStageEvent): void;
-  wheelStage(payload: SigmaStageEvent): void;
+  // Additional node events
+  enterNode(payload: Pick<SigmaNodeEventPayload, "node">): void;
+  leaveNode(payload: Pick<SigmaNodeEventPayload, "node">): void;
 
-  // Node events
-  enterNode(payload: SigmaNodeEvent): void;
-  leaveNode(payload: SigmaNodeEvent): void;
-  clickNode(payload: SigmaNodeEvent): void;
-  rightClickNode(payload: SigmaNodeEvent): void;
-  doubleClickNode(payload: SigmaNodeEvent): void;
-  wheelNode(payload: SigmaNodeEvent): void;
-
-  // Edge events
-  enterEdge(payload: SigmaEdgeEvent): void;
-  leaveEdge(payload: SigmaEdgeEvent): void;
-  clickEdge(payload: SigmaEdgeEvent): void;
-  rightClickEdge(payload: SigmaEdgeEvent): void;
-  doubleClickEdge(payload: SigmaEdgeEvent): void;
-  wheelEdge(payload: SigmaEdgeEvent): void;
+  // Additional edge events
+  enterEdge(payload: Pick<SigmaEdgeEventPayload, "edge">): void;
+  leaveEdge(payload: Pick<SigmaEdgeEventPayload, "edge">): void;
 };
+
+type SigmaEvents = SigmaStageEvents & SigmaNodeEvents & SigmaEdgeEvents & SigmaAdditionalEvents;
 
 /**
  * Main class.
@@ -498,7 +497,7 @@ export default class Sigma extends (EventEmitter as unknown as new () => TypedEv
     };
 
     // Handling click
-    const createMouseListener = (eventType: string): ((e: MouseCoords) => void) => {
+    const createMouseListener = (eventType: MouseInteraction): ((e: MouseCoords) => void) => {
       return (e) => {
         const baseEvent = {
           event: e,

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -205,6 +205,7 @@ export default class Sigma extends (EventEmitter as unknown as new () => TypedEv
     super();
 
     this.settings = assign<Settings>({}, DEFAULT_SETTINGS, settings);
+    this.rawEmitter = this as EventEmitter;
 
     // Validating
     validateSettings(this.settings);

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -3,7 +3,6 @@
  * ========
  * @module
  */
-import { EventEmitter } from "events";
 import graphExtent from "graphology-metrics/extent";
 import Graph from "graphology";
 
@@ -20,6 +19,7 @@ import {
   MouseCoords,
   NodeDisplayData,
   PlainObject,
+  TypedEventEmitter,
 } from "./types";
 import {
   createElement,
@@ -95,6 +95,52 @@ function applyEdgeDefaults(settings: Settings, key: string, data: Partial<EdgeDi
 }
 
 /**
+ * Event types.
+ */
+interface SigmaEvent {
+  event: MouseCoords;
+  preventSigmaDefault(): void;
+}
+
+interface SigmaStageEvent extends SigmaEvent {}
+
+interface SigmaNodeEvent extends SigmaEvent {
+  node: string;
+}
+
+interface SigmaEdgeEvent extends SigmaEvent {
+  edge: string;
+}
+
+type SigmaEvents = {
+  // Lifecycle events
+  afterRender(): void;
+  kill(): void;
+
+  // Stage events
+  clickStage(payload: SigmaStageEvent): void;
+  rightClickStage(payload: SigmaStageEvent): void;
+  doubleClickStage(payload: SigmaStageEvent): void;
+  wheelStage(payload: SigmaStageEvent): void;
+
+  // Node events
+  enterNode(payload: SigmaNodeEvent): void;
+  leaveNode(payload: SigmaNodeEvent): void;
+  clickNode(payload: SigmaNodeEvent): void;
+  rightClickNode(payload: SigmaNodeEvent): void;
+  doubleClickNode(payload: SigmaNodeEvent): void;
+  wheelNode(payload: SigmaNodeEvent): void;
+
+  // Edge events
+  enterEdge(payload: SigmaEdgeEvent): void;
+  leaveEdge(payload: SigmaEdgeEvent): void;
+  clickEdge(payload: SigmaEdgeEvent): void;
+  rightClickEdge(payload: SigmaEdgeEvent): void;
+  doubleClickEdge(payload: SigmaEdgeEvent): void;
+  wheelEdge(payload: SigmaEdgeEvent): void;
+};
+
+/**
  * Main class.
  *
  * @constructor
@@ -102,7 +148,7 @@ function applyEdgeDefaults(settings: Settings, key: string, data: Partial<EdgeDi
  * @param {HTMLElement} container - DOM container in which to render.
  * @param {object}      settings  - Optional settings.
  */
-export default class Sigma extends EventEmitter {
+export default class Sigma extends TypedEventEmitter<SigmaEvents> {
   private settings: Settings;
   private graph: Graph;
   private mouseCaptor: MouseCaptor;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@
  * Various type declarations used throughout the library.
  * @module
  */
+import { EventEmitter } from "events";
 
 /**
  * Util type to represent maps of typed elements, but implemented with
@@ -26,9 +27,6 @@ export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>> &
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PartialButFor<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>> & { [others: string]: any };
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Listener = (...args: any[]) => void;
 
 export interface Coordinates {
   x: number;
@@ -88,3 +86,39 @@ export interface NodeDisplayData extends Coordinates, DisplayData {
 }
 
 export interface EdgeDisplayData extends DisplayData {}
+
+/**
+ * Custom event emitter types.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Listener = (...args: any[]) => void;
+
+export declare class TypedEventEmitter<Events extends Record<string, Listener>> extends EventEmitter {
+  static listenerCount(emitter: EventEmitter, type: string | symbol): number;
+  static defaultMaxListeners: number;
+
+  eventNames(): Array<string | symbol>;
+  setMaxListeners(n: number): this;
+  getMaxListeners(): number;
+  emit<Event extends keyof Events>(type: Event, ...args: Parameters<Events[Event]>): boolean;
+  emit(type: string | symbol, ...args: any[]): boolean;
+  addListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
+  addListener(type: string | number, listener: Listener): this;
+  on<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
+  on(type: string | number, listener: Listener): this;
+  once<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
+  once(type: string | number, listener: Listener): this;
+  prependListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
+  prependListener(type: string | number, listener: Listener): this;
+  prependOnceListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
+  prependOnceListener(type: string | number, listener: Listener): this;
+  removeListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
+  removeListener(type: string | number, listener: Listener): this;
+  off<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
+  off(type: string | number, listener: Listener): this;
+  removeAllListeners<Event extends keyof Events>(type?: Event): this;
+  removeAllListeners(type?: string | number): this;
+  listeners(type: string | symbol): Listener[];
+  listenerCount(type: string | symbol): number;
+  rawListeners(type: string | symbol): Listener[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,8 +87,9 @@ export interface EdgeDisplayData extends DisplayData {}
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Listener = (...args: any[]) => void;
+export type EventsMapping = Record<string, Listener>;
 
-export declare class TypedEventEmitter<Events extends Record<string, Listener>> {
+interface ITypedEventEmitter<Events extends EventsMapping> {
   rawEmitter: EventEmitter;
 
   eventNames<Event extends keyof Events>(): Array<Event>;
@@ -106,4 +107,13 @@ export declare class TypedEventEmitter<Events extends Record<string, Listener>> 
   listeners<Event extends keyof Events>(type: Event): Events[Event][];
   listenerCount<Event extends keyof Events>(type: Event): number;
   rawListeners<Event extends keyof Events>(type: Event): Events[Event][];
+}
+
+export class TypedEventEmitter<Events extends EventsMapping> extends (EventEmitter as unknown as {
+  new <T extends EventsMapping>(): ITypedEventEmitter<T>;
+})<Events> {
+  constructor() {
+    super();
+    this.rawEmitter = this as EventEmitter;
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,7 @@ export declare class TypedEventEmitter<Events extends Record<string, Listener>> 
   setMaxListeners(n: number): this;
   getMaxListeners(): number;
   emit<Event extends keyof Events>(type: Event, ...args: Parameters<Events[Event]>): boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   emit(type: string | symbol, ...args: any[]): boolean;
   addListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
   addListener(type: string | number, listener: Listener): this;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,13 +16,6 @@ export type PlainObject<T = any> = { [k: string]: T };
 
 /**
  * Returns a type similar to T, but with the the K set of properties of the type
- * T optional.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>> & { [others: string]: any };
-
-/**
- * Returns a type similar to T, but with the the K set of properties of the type
  * T *required*, and the rest optional.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,8 @@ export interface CameraState extends Coordinates {
   ratio: number;
 }
 
+export type MouseInteraction = "click" | "doubleClick" | "rightClick" | "wheel" | "down";
+
 export interface MouseCoords extends Coordinates {
   clientX: number;
   clientY: number;
@@ -93,35 +95,22 @@ export interface EdgeDisplayData extends DisplayData {}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Listener = (...args: any[]) => void;
 
-export declare class TypedEventEmitter<Events extends Record<string, Listener>> extends EventEmitter {
-  static listenerCount(emitter: EventEmitter, type: string | symbol): number;
-  static defaultMaxListeners: number;
-
+export declare class TypedEventEmitter<Events extends Record<string, Listener>> {
   rawEmitter: EventEmitter;
 
-  eventNames(): Array<string | symbol>;
+  eventNames<Event extends keyof Events>(): Array<Event>;
   setMaxListeners(n: number): this;
   getMaxListeners(): number;
   emit<Event extends keyof Events>(type: Event, ...args: Parameters<Events[Event]>): boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  emit(type: string | symbol, ...args: any[]): boolean;
   addListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
-  addListener(type: string | number, listener: Listener): this;
   on<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
-  on(type: string | number, listener: Listener): this;
   once<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
-  once(type: string | number, listener: Listener): this;
   prependListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
-  prependListener(type: string | number, listener: Listener): this;
   prependOnceListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
-  prependOnceListener(type: string | number, listener: Listener): this;
   removeListener<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
-  removeListener(type: string | number, listener: Listener): this;
   off<Event extends keyof Events>(type: Event, listener: Events[Event]): this;
-  off(type: string | number, listener: Listener): this;
   removeAllListeners<Event extends keyof Events>(type?: Event): this;
-  removeAllListeners(type?: string | number): this;
-  listeners(type: string | symbol): Listener[];
-  listenerCount(type: string | symbol): number;
-  rawListeners(type: string | symbol): Listener[];
+  listeners<Event extends keyof Events>(type: Event): Events[Event][];
+  listenerCount<Event extends keyof Events>(type: Event): number;
+  rawListeners<Event extends keyof Events>(type: Event): Events[Event][];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,8 @@ export declare class TypedEventEmitter<Events extends Record<string, Listener>> 
   static listenerCount(emitter: EventEmitter, type: string | symbol): number;
   static defaultMaxListeners: number;
 
+  rawEmitter: EventEmitter;
+
   eventNames(): Array<string | symbol>;
   setMaxListeners(n: number): this;
   getMaxListeners(): number;


### PR DESCRIPTION
@jacomyal don't merge yet.

Things to decide: do we want a strict event emitter (that does not allow emitting or listening to arbitrary events beyond our control, in TS at least)? I would personally vouch for a strict emitter, which is at least very useful to us when coding the lib and if people want to emit/listen to custom events, they can do so using their own event emitter without piggybacking sigma's one?

I haven't found a way to "override" an existing implementation using a declaration (without implementation) without relying on this ugly trick:

```ts
class Sigma extends (EventEmitter as unknown as new () => TypedEventEmitter<SigmaEvents>) {}
```

I cannot remove the unknown because the way the `events` module is typed is not very sound. I have also thought of overriding with:

```ts
declare module "events" {}
```

but this makes thing complicated for transpilation and shipping of the lib I think.

Note that I chose to declare the generic typed event emitter in `types.ts` but to declare the events to pass as generics in `sigma.ts`, closer to where they are used. Tell me if you feel those would be better off in `types.ts` also.

Things that remain to be done:

- [x] Make a decision about strictness
- [x] Drop some now useless types in `types.ts`
- [x] Properly type Camera events
- [x] Properly type Captor events
- [x] Add missing payload elements for leave/enter events?