### PR TITLE
hover/click event ignores hidden nodes

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -398,7 +398,7 @@ export default class Sigma extends EventEmitter {
 
         const size = this.scaleSize(data.size);
 
-        if (mouseIsOnNode(e.x, e.y, pos.x, pos.y, size)) {
+        if (!data.hidden && mouseIsOnNode(e.x, e.y, pos.x, pos.y, size)) {
           const distance = Math.sqrt(Math.pow(e.x - pos.x, 2) + Math.pow(e.y - pos.y, 2));
 
           // TODO: sort by min size also for cases where center is the same


### PR DESCRIPTION
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Current Behavior
If a hidden node overlaps a visible node, it can prevent hover/click events over some portion of the visible node. This is because hidden nodes are not omitted from the search for the currently hovered node.

### To reproduce
In this [code sandbox](https://codesandbox.io/s/hidden-node-interaction-v2lle?file=/index.ts), move the mouse into the grey node from the right of the screen - the grey node will not be hovered for a short distance while the mouse is inside it because a hidden node is in front of it.

### New Behavior
Hidden nodes are no longer considered for hover events so they don't prevent events on visible nodes.

### Notes
- This is a small addendum to issue #1157. The fix we implemented doesn't address this case.
- There is another check for node hovering [here](https://github.com/jacomyal/sigma.js/blob/ac658739e7fe3a08ad8db4ea831eba798b9fd99e/src/sigma.ts#L430), but I wasn't sure if that required a check for the hidden attribute as well - it didn't affect anything that I could observe.
