### PR TITLE
Fixing labelgrid cell indexing & adjusting defaults

### DIFF
--- a/src/core/labels.ts
+++ b/src/core/labels.ts
@@ -65,7 +65,7 @@ export class LabelGrid {
     const xIndex = Math.floor(pos.x / this.cellSize);
     const yIndex = Math.floor(pos.y / this.cellSize);
 
-    return xIndex * this.columns + yIndex;
+    return yIndex * this.columns + xIndex;
   }
 
   add(key: string, size: number, pos: Coordinates): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -96,8 +96,8 @@ export const DEFAULT_SETTINGS: Settings = {
   stagePadding: 30,
 
   // Labels
-  labelDensity: 0.07,
-  labelGridCellSize: 60,
+  labelDensity: 1,
+  labelGridCellSize: 250,
   labelRenderedSizeThreshold: 6,
 
   // Reducers


### PR DESCRIPTION
@jacomyal this PR:

1. Fixes the erroneous label grid cell indexing (I mixed up rows & columns it seems)
2. Adjusts the default label grid settings according to intuition, e.g. the default density is now `1` and not some strange float and the cell size is around `250` pixels wide.

This needs to be tested on your end to tell whether the displayed labels still seem sensible according to you.