### PR TITLE
Dropping dep on graphology-metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@yomguithereal/helpers": "^1.1.1",
         "events": "^3.3.0",
-        "graphology-metrics": "1.18.2",
         "graphology-utils": "^2.4.0"
       },
       "devDependencies": {
@@ -3486,6 +3485,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/graphology-indices/-/graphology-indices-0.16.0.tgz",
       "integrity": "sha512-ZsuDIrmpRU9NlwRp5yi4CDIBjYoF9q0JSOt30BideCQOjsJzkO6CEOU7qXR8BYe5ZBwYqGOmoJM295DxTtu+QQ==",
+      "dev": true,
       "dependencies": {
         "graphology-utils": "^2.1.2",
         "mnemonist": "^0.38.0"
@@ -3517,6 +3517,7 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/graphology-metrics/-/graphology-metrics-1.18.2.tgz",
       "integrity": "sha512-Ex02yMIyIzEmaQxcMUNqCvCRT0bxV008wuGZcD3lVwssubJK3vj6FktmZY1A24ASN5INn2TJ0n/x40mWGyPkhA==",
+      "dev": true,
       "dependencies": {
         "graphology-shortest-path": "^1.5.2",
         "graphology-utils": "^2.3.0",
@@ -3530,6 +3531,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/graphology-shortest-path/-/graphology-shortest-path-1.5.2.tgz",
       "integrity": "sha512-MP95GPiPSkutan5miLfWrMQMWKO/rVSzrfqknrKZ2HyJYDFWonr0IDZOn8MsgR8bNCXKUTd3cFAzKo8hVISx/A==",
+      "dev": true,
       "dependencies": {
         "@yomguithereal/helpers": "^1.1.1",
         "graphology-indices": "^0.16.0",
@@ -4730,6 +4732,7 @@
       "version": "0.38.5",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
       "integrity": "sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==",
+      "dev": true,
       "dependencies": {
         "obliterator": "^2.0.0"
       }
@@ -4998,7 +5001,8 @@
     "node_modules/obliterator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.0.tgz",
-      "integrity": "sha512-DJaXYKqe9Rs7c2+Xu08Knkt8P60rTeByyy7IWoXLqyc6ln9ph9NAo6ZbiylDpAshsygzBr81pZL5q6/dqi0RtQ=="
+      "integrity": "sha512-DJaXYKqe9Rs7c2+Xu08Knkt8P60rTeByyy7IWoXLqyc6ln9ph9NAo6ZbiylDpAshsygzBr81pZL5q6/dqi0RtQ==",
+      "dev": true
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -10470,6 +10474,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/graphology-indices/-/graphology-indices-0.16.0.tgz",
       "integrity": "sha512-ZsuDIrmpRU9NlwRp5yi4CDIBjYoF9q0JSOt30BideCQOjsJzkO6CEOU7qXR8BYe5ZBwYqGOmoJM295DxTtu+QQ==",
+      "dev": true,
       "requires": {
         "graphology-utils": "^2.1.2",
         "mnemonist": "^0.38.0"
@@ -10497,6 +10502,7 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/graphology-metrics/-/graphology-metrics-1.18.2.tgz",
       "integrity": "sha512-Ex02yMIyIzEmaQxcMUNqCvCRT0bxV008wuGZcD3lVwssubJK3vj6FktmZY1A24ASN5INn2TJ0n/x40mWGyPkhA==",
+      "dev": true,
       "requires": {
         "graphology-shortest-path": "^1.5.2",
         "graphology-utils": "^2.3.0",
@@ -10507,6 +10513,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/graphology-shortest-path/-/graphology-shortest-path-1.5.2.tgz",
       "integrity": "sha512-MP95GPiPSkutan5miLfWrMQMWKO/rVSzrfqknrKZ2HyJYDFWonr0IDZOn8MsgR8bNCXKUTd3cFAzKo8hVISx/A==",
+      "dev": true,
       "requires": {
         "@yomguithereal/helpers": "^1.1.1",
         "graphology-indices": "^0.16.0",
@@ -11392,6 +11399,7 @@
       "version": "0.38.5",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
       "integrity": "sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==",
+      "dev": true,
       "requires": {
         "obliterator": "^2.0.0"
       }
@@ -11594,7 +11602,8 @@
     "obliterator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.0.tgz",
-      "integrity": "sha512-DJaXYKqe9Rs7c2+Xu08Knkt8P60rTeByyy7IWoXLqyc6ln9ph9NAo6ZbiylDpAshsygzBr81pZL5q6/dqi0RtQ=="
+      "integrity": "sha512-DJaXYKqe9Rs7c2+Xu08Knkt8P60rTeByyy7IWoXLqyc6ln9ph9NAo6ZbiylDpAshsygzBr81pZL5q6/dqi0RtQ==",
+      "dev": true
     },
     "obuf": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@yomguithereal/helpers": "^1.1.1",
     "events": "^3.3.0",
-    "graphology-metrics": "1.18.2",
     "graphology-utils": "^2.4.0"
   },
   "devDependencies": {

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -4,7 +4,6 @@
  * @module
  */
 import { EventEmitter } from "events";
-import graphExtent from "graphology-metrics/extent";
 import Graph from "graphology";
 
 import Camera from "./core/camera";
@@ -33,6 +32,7 @@ import {
   validateGraph,
   zIndexOrdering,
   getMatrixImpact,
+  graphExtent,
 } from "./utils";
 import { edgeLabelsToDisplayFromNodes, LabelGrid } from "./core/labels";
 import { Settings, DEFAULT_SETTINGS, validateSettings } from "./settings";
@@ -41,8 +41,6 @@ import { IEdgeProgram } from "./rendering/webgl/programs/common/edge";
 import TouchCaptor from "./core/captors/touch";
 import { identity, multiplyVec } from "./utils/matrices";
 import { doEdgeCollideWithPoint, isPixelColored } from "./utils/edge-collisions";
-
-const { nodeExtent } = graphExtent;
 
 /**
  * Constants.
@@ -640,9 +638,7 @@ export default class Sigma extends EventEmitter {
     this.highlightedNodes = new Set();
 
     // Computing extents
-    const nodeExtentProperties = ["x", "y"];
-
-    this.nodeExtent = nodeExtent(graph, nodeExtentProperties) as { x: Extent; y: Extent };
+    this.nodeExtent = graphExtent(graph);
 
     // NOTE: it is important to compute this matrix after computing the node's extent
     // because #.getGraphDimensions relies on it
@@ -1568,7 +1564,7 @@ export default class Sigma extends EventEmitter {
    * @return {{ x: Extent, y: Extent }}
    */
   getBBox(): { x: Extent; y: Extent } {
-    return nodeExtent(this.graph, ["x", "y"]) as { x: Extent; y: Extent };
+    return graphExtent(this.graph);
   }
 
   /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,8 +5,7 @@
  * Various helper functions & classes used throughout the library.
  * @module
  */
-import Graph from "graphology";
-import { Attributes } from "graphology-types";
+import Graph, { Attributes } from "graphology-types";
 import isGraph from "graphology-utils/is-graph";
 import { CameraState, Coordinates, Dimensions, Extent, PlainObject } from "../types";
 import { multiply, identity, scale, rotate, translate, multiplyVec } from "./matrices";
@@ -121,6 +120,31 @@ export function getPixelRatio(): number {
   if (typeof window.devicePixelRatio !== "undefined") return window.devicePixelRatio;
 
   return 1;
+}
+
+/**
+ * Function returning the graph's node extent in x & y.
+ *
+ * @param  {Graph}
+ * @return {object}
+ */
+export function graphExtent(graph: Graph): { x: Extent; y: Extent } {
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+
+  graph.forEachNode((_, attr) => {
+    const { x, y } = attr;
+
+    if (x < xMin) xMin = x;
+    if (x > xMax) xMax = x;
+
+    if (y < yMin) yMin = y;
+    if (y > yMax) yMax = y;
+  });
+
+  return { x: [xMin, xMax], y: [yMin, yMax] };
 }
 
 /**


### PR DESCRIPTION
@jacomyal this PR drops the dep on `graphology-metrics` since it is only used for extent computation and I have a feeling it would simplify our maintenance work in the future. This said, while doing so I have a sinister intuition that we compute this extent before applying reducers and this might be an issue if positions were to be given straight from the reducers or modified (thing we never really did yet I think).