### PR TITLE
Overlapping edge hover/click events

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -595,25 +595,41 @@ export default class Sigma extends EventEmitter {
     // If no non-null edge has been found, return null:
     if (!transformationRatio) return null;
 
-    // Now we can look for a matching edge:
-    return (
-      this.graph.findEdge((key, edgeAttributes, _s, _t, sourcePosition, targetPosition) => {
-        if (
-          doEdgeCollideWithPoint(
-            graphX,
-            graphY,
-            sourcePosition.x,
-            sourcePosition.y,
-            targetPosition.x,
-            targetPosition.y,
-            // Adapt the edge size to the zoom ratio:
-            (edgeDataCache[key].size * transformationRatio) / this.cameraSizeRatio,
-          )
-        ) {
-          return true;
-        }
-      }) || null
-    );
+    // Now we can look for matching edges:
+    const edges = this.graph.filterEdges((key, edgeAttributes, sourceId, targetId, sourcePosition, targetPosition) => {
+      if (edgeDataCache[key].hidden || nodeDataCache[sourceId].hidden || nodeDataCache[targetId].hidden) return false;
+      if (
+        doEdgeCollideWithPoint(
+          graphX,
+          graphY,
+          sourcePosition.x,
+          sourcePosition.y,
+          targetPosition.x,
+          targetPosition.y,
+          // Adapt the edge size to the zoom ratio:
+          (edgeDataCache[key].size * transformationRatio) / this.cameraSizeRatio,
+        )
+      ) {
+        return true;
+      }
+    });
+
+    if (edges.length === 0) return null; // no edges found
+
+    // if none of the edges have a zIndex, selected the most recently created one to match the rendering order
+    let selectedEdge = edges[edges.length - 1];
+
+    // otherwise select edge with highest zIndex
+    let highestZIndex = -Infinity;
+    for (const edge of edges) {
+      const zIndex = this.graph.getEdgeAttribute(edge, "zIndex");
+      if (zIndex >= highestZIndex) {
+        selectedEdge = edge;
+        highestZIndex = zIndex;
+      }
+    }
+
+    return selectedEdge;
   }
 
   /**


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Current Behavior
When edges overlap, edge click/hover events do not correspond to the visual order that they appear to overlap in, resulting in some edges triggering events even though they may not be visible, and other edges not triggering events even though they are. Additionally, hidden edges can block events from other overlapping edges.

See this [codesandbox](https://codesandbox.io/s/7w1tf) for a minimal demonstration. In each row, there are two overlapping edges, a wide red edge and a thin green edge.
- In the top row, the green edge is created last, and is therefore rendered in front of the red edge, yet only the red edge triggers events in the overlapping region.
- In the middle row, the same is done except the green edge is given a zIndex of 1 in an attempt to bring it to the front, but behavior is the same as the first row.
- In the bottom row, the red edge is created last instead, and is therefore rendered in front of the green edge, but now the green edge triggers events in the overlapping region even though it is not visible from behind the red edge.
- Also, uncommenting lines 80-82 will hide all red edges, but they still interfere with events on the green edge in the overlapping region.

## New behavior
Edges now trigger events according to the order in which they are rendered and zIndex, and completely ignore hidden edges.

## Other information
When we tackled a similar issue with overlapping nodes, we discussed the premise that a user should be able to hover/click any node regardless of whether it is obscured by a node in front of it. Unlike nodes, however, edges do not currently pop to the front when hovered, so I was not able to uphold that premise in this case. Instead, the most recently created edge is selected unless there is an edge with a higher zIndex.

The way I selected the most recently created edge is just by taking the last edge in the array returned by graph.filterEdges(). I'm not totally certain that this behavior is consistent, but if it isn't that will need to be modified. Let me know what you think of this solution.
