### PR TITLE
Node label rendering and hidden nodes

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -719,7 +719,7 @@ export default class Sigma extends EventEmitter {
 
       this.quadtree.add(node, data.x, 1 - data.y, data.size / this.width);
 
-      if (data.label)
+      if (data.label && !data.hidden)
         this.labelGrid.add(node, data.size, this.framedGraphToViewport(data, { matrix: nullCameraMatrix }));
 
       this.nodePrograms[data.type].process(data, data.hidden, nodesPerPrograms[data.type]++);


### PR DESCRIPTION
## Pull request type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Current Behavior
If there is a visible node with a larger, hidden node close to it, the visible node's label will not be selected to render in favor of the hidden node's label, which is not displayed. This results in no label being displayed for either.

## New Behavior
There is now a check to see whether a node is hidden before adding it to the grid of label candidates.

## Other information
As far as I can tell, this does not interfere with #1172.