### PR TITLE
#1207 fix canvas size calculation

### DIFF
--- a/src/rendering/webgl/programs/node.image.ts
+++ b/src/rendering/webgl/programs/node.image.ts
@@ -104,8 +104,14 @@ export default function getNodeImageProgram(): typeof AbstractNodeImageProgram {
     const canvas = document.createElement("canvas");
     const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
 
-    canvas.width = pendingImages.reduce((iter, { size }) => iter + size, hasReceivedImages ? textureImage.width : 0);
-    canvas.height = Math.max(hasReceivedImages ? textureImage.height : 0, ...pendingImages.map(({ size }) => size));
+    canvas.width = pendingImages.reduce(
+      (iter, { size }) => iter + Math.min(MAX_TEXTURE_SIZE, size),
+      hasReceivedImages ? textureImage.width : 0,
+    );
+    canvas.height = Math.max(
+      hasReceivedImages ? textureImage.height : 0,
+      ...pendingImages.map(({ size }) => Math.min(MAX_TEXTURE_SIZE, size)),
+    );
 
     let xOffset = 0;
     if (hasReceivedImages) {


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: #1207 (quick fix)

## What is the new behavior?

Canvas width calculation is now respecting MAX_TEXTURE_SIZE

## Other information

I did not check this fix very thoroughly because I'm now using the atlas texture from #1198. But I still had this in the head as first fix.
