### PR TITLE
Optimizing multiplyVec2

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -41,7 +41,7 @@ import { Settings, DEFAULT_SETTINGS, validateSettings } from "./settings";
 import { INodeProgram } from "./rendering/webgl/programs/common/node";
 import { IEdgeProgram } from "./rendering/webgl/programs/common/edge";
 import TouchCaptor from "./core/captors/touch";
-import { identity, multiplyVec } from "./utils/matrices";
+import { identity, multiplyVec2 } from "./utils/matrices";
 import { doEdgeCollideWithPoint, isPixelColored } from "./utils/edge-collisions";
 
 /**
@@ -1591,12 +1591,11 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
         )
       : this.matrix;
 
-    const framedGraphVec = [coordinates.x, coordinates.y, 1];
-    const viewportVec = multiplyVec(matrix, framedGraphVec);
+    const viewportPos = multiplyVec2(matrix, coordinates);
 
     return {
-      x: ((1 + viewportVec[0]) * this.width) / 2,
-      y: ((1 - viewportVec[1]) * this.height) / 2,
+      x: ((1 + viewportPos.x) * this.width) / 2,
+      y: ((1 - viewportPos.y) * this.height) / 2,
     };
   }
 
@@ -1621,13 +1620,10 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
         )
       : this.invMatrix;
 
-    const viewportVec = [(coordinates.x / this.width) * 2 - 1, 1 - (coordinates.y / this.height) * 2, 1];
-    const framedGraphVec = multiplyVec(invMatrix, viewportVec);
-
-    return {
-      x: framedGraphVec[0],
-      y: framedGraphVec[1],
-    };
+    return multiplyVec2(invMatrix, {
+      x: (coordinates.x / this.width) * 2 - 1,
+      y: 1 - (coordinates.y / this.height) * 2,
+    });
   }
 
   /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,7 @@
 import Graph, { Attributes } from "graphology-types";
 import isGraph from "graphology-utils/is-graph";
 import { CameraState, Coordinates, Dimensions, Extent, PlainObject } from "../types";
-import { multiply, identity, scale, rotate, translate, multiplyVec } from "./matrices";
+import { multiply, identity, scale, rotate, translate, multiplyVec2 } from "./matrices";
 import { HTML_COLORS } from "./data";
 
 /**
@@ -388,7 +388,7 @@ export function getMatrixImpact(
   cameraState: CameraState,
   viewportDimensions: Dimensions,
 ): number {
-  const [x, y] = multiplyVec(matrix, [Math.cos(cameraState.angle), Math.sin(cameraState.angle), 0]);
+  const { x, y } = multiplyVec2(matrix, { x: Math.cos(cameraState.angle), y: Math.sin(cameraState.angle) }, 0);
   return 1 / Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2)) / viewportDimensions.width;
 }
 

--- a/src/utils/matrices.ts
+++ b/src/utils/matrices.ts
@@ -5,6 +5,7 @@
  * Matrices-related helper functions used by sigma's WebGL renderer.
  * @module
  */
+import { Coordinates } from "../types";
 
 export function identity(): Float32Array {
   return Float32Array.of(1, 0, 0, 0, 1, 0, 0, 0, 1);
@@ -73,26 +74,16 @@ export function multiply<T extends number[] | Float32Array>(a: T, b: Float32Arra
   return a;
 }
 
-export function multiplyVec<T extends number[] | Float32Array>(a: Float32Array | number[], b: T): T {
-  const a00 = a[0],
-    a01 = a[1],
-    a02 = a[2];
-  const a10 = a[3],
-    a11 = a[4],
-    a12 = a[5];
-  const a20 = a[6],
-    a21 = a[7],
-    a22 = a[8];
+export function multiplyVec2(a: Float32Array | number[], b: Coordinates, z: number = 1): Coordinates {
+  const a00 = a[0];
+  const a01 = a[1];
+  const a10 = a[3];
+  const a11 = a[4];
+  const a20 = a[6];
+  const a21 = a[7];
 
-  const b0 = b[0],
-    b1 = b[1],
-    b2 = b[2];
+  const b0 = b.x;
+  const b1 = b.y;
 
-  const c = Array.isArray(b) ? [0, 0, 0] : Float32Array.of(0, 0, 0);
-
-  c[0] = b0 * a00 + b1 * a10 + b2 * a20;
-  c[1] = b0 * a01 + b1 * a11 + b2 * a21;
-  c[2] = b0 * a02 + b1 * a12 + b2 * a22;
-
-  return c as T;
+  return { x: b0 * a00 + b1 * a10 + a20 * z, y: b0 * a01 + b1 * a11 + a21 * z };
 }


### PR DESCRIPTION
This version uses less operations and should be marginally faster. It also takes `Coordinates` directly and return `Coordinates` which should cut down some unnecessary transition objects in memory.