### PR TITLE
Add renderEdges setting

### DIFF
--- a/examples/large-graphs/index.html
+++ b/examples/large-graphs/index.html
@@ -77,6 +77,10 @@
             <input type="radio" name="edges-renderer" id="edges-fast" value="edges-fast" checked />
             <label for="edges-fast">Faster (only 1px thick edges)</label>
           </div>
+          <div>
+            <input type="radio" name="edges-renderer" id="edges-hidden" value="edges-hidden" checked />
+            <label for="edges-hidden">Hidden</label>
+          </div>
         </fieldset>
         <fieldset>
           <button type="submit">Reset graph</button>

--- a/examples/large-graphs/index.ts
+++ b/examples/large-graphs/index.ts
@@ -61,9 +61,11 @@ const container = document.getElementById("sigma-container") as HTMLElement;
 const renderer = new Sigma(graph, container, {
   defaultEdgeColor: "#e6e6e6",
   defaultEdgeType: state.edgesRenderer,
+  renderEdges: state.edgesRenderer === 'edges-hidden' ? false : true,
   edgeProgramClasses: {
     "edges-default": EdgesDefaultProgram,
     "edges-fast": EdgesFastProgram,
+    "edges-hidden": EdgesFastProgram,
   },
 });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,6 +39,7 @@ export interface Settings {
   // Performance
   hideEdgesOnMove: boolean;
   hideLabelsOnMove: boolean;
+  renderEdges: boolean,
   renderLabels: boolean;
   renderEdgeLabels: boolean;
   enableEdgeClickEvents: boolean;
@@ -85,6 +86,7 @@ export const DEFAULT_SETTINGS: Settings = {
   // Performance
   hideEdgesOnMove: false,
   hideLabelsOnMove: false,
+  renderEdges: true,
   renderLabels: true,
   renderEdgeLabels: false,
   enableEdgeClickEvents: false,

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -1221,7 +1221,7 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
     }
 
     // Drawing edges
-    if (!this.settings.hideEdgesOnMove || !moving) {
+    if ((!this.settings.hideEdgesOnMove || !moving) && this.settings.renderEdges) {
       for (const type in this.edgePrograms) {
         const program = this.edgePrograms[type];
 


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently sigma.js does not have the ability to hide the rendering of edges via a setting. Such a setting is added here. There are two primary motivations for doing so: 
1. Per https://github.com/jacomyal/sigma.js/issues/1197 this setting should allow for custom canvas edge rendering by users so that curved edges and self-loops may be added by those users. 
2. Performance improvements for large graphs. 

## What is the new behavior?

The user now can show/hide edges via a setting. This setting is set to true by default, i.e. no change in default behaviour.   

## Other information

The large-graphs example has been adapted to illustrate the new setting. This is just to illustrate and need not be included. 
