### PR TITLE
feat: add `getContainer` method to public api

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -1272,6 +1272,15 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
   }
 
   /**
+   * Method returning the container DOM element.
+   *
+   * @return {HTMLElement}
+   */
+  getContainer(): HTMLElement {
+    return this.container;
+  }
+
+  /**
    * Method returning the renderer's graph.
    *
    * @return {Graph}


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

> **_NOTE:_** Describe the current behavior that you are modifying, or link to a relevant issue.

Currently, there seems to be no way to get the container dom element from a sigma renderer instance.

## What is the new behavior?

> **_NOTE:_** Describe the behavior or changes that are being added by this PR.

This PR adds a new `getContainer` method to the public api, which simply returns the container dom element.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.

This can be useful e.g. for toggling fullscreen mode on the container dom element. It would also avoid having to pass down the container element separately via React context in `react-sigma` (see https://github.com/sim51/react-sigma/blob/main/packages/core/src/components/SigmaContainer.tsx#L91).