### PR TITLE
Fix touch events relative to container

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -494,7 +494,7 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
         };
 
         const isFakeSigmaMouseEvent = (e.original as FakeSigmaMouseEvent).isFakeSigmaMouseEvent;
-        const nodeAtPosition = isFakeSigmaMouseEvent ? this.getNodeAtPosition(e) : this.hoveredNode;
+        const nodeAtPosition = isFakeSigmaMouseEvent ? this.getNodeAtPosition(e.original) : this.hoveredNode;
 
         if (nodeAtPosition)
           return this.emit(`${eventType}Node`, {


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Touch events work only correctly if the container left / top is at (0,0). If the sigma container is shifted, the wrong position of the fake events is propagated.

## What is the new behavior?
The container-relative (original) coordinates of the (synthetic) fake touch events are used. 
