### PR TITLE
Configurable size-ratio calculation for custom node programs

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,6 +59,7 @@ export interface Settings {
   edgeLabelColor: { attribute: string; color?: string } | { color: string; attribute?: undefined };
   stagePadding: number;
   getCameraSizeRatio: (ratio: number) => number;
+  scaleSize: (size: number, cameraRatio: number) => number;
   // Labels
   labelDensity: number;
   labelGridCellSize: number;
@@ -109,6 +110,7 @@ export const DEFAULT_SETTINGS: Settings = {
 
   // Camera to size ratio function
   getCameraSizeRatio: (ratio: number) => Math.sqrt(ratio),
+  scaleSize: (size: number, cameraRatio: number) => 1 / Math.sqrt(cameraRatio),
 
   // Labels
   labelDensity: 1,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,7 +59,7 @@ export interface Settings {
   edgeLabelColor: { attribute: string; color?: string } | { color: string; attribute?: undefined };
   stagePadding: number;
   getCameraSizeRatio: (ratio: number) => number;
-  scaleSize: (size: number, cameraRatio: number) => number;
+
   // Labels
   labelDensity: number;
   labelGridCellSize: number;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -110,7 +110,6 @@ export const DEFAULT_SETTINGS: Settings = {
 
   // Camera to size ratio function
   getCameraSizeRatio: (ratio: number) => Math.sqrt(ratio),
-  scaleSize: (size: number, cameraRatio: number) => 1 / Math.sqrt(cameraRatio),
 
   // Labels
   labelDensity: 1,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -58,6 +58,7 @@ export interface Settings {
   edgeLabelWeight: string;
   edgeLabelColor: { attribute: string; color?: string } | { color: string; attribute?: undefined };
   stagePadding: number;
+  getCameraSizeRatio: (ratio: number) => number;
   // Labels
   labelDensity: number;
   labelGridCellSize: number;
@@ -105,6 +106,9 @@ export const DEFAULT_SETTINGS: Settings = {
   edgeLabelWeight: "normal",
   edgeLabelColor: { attribute: "color" },
   stagePadding: 30,
+
+  // Camera to size ratio function
+  getCameraSizeRatio: (ratio: number) => Math.sqrt(ratio),
 
   // Labels
   labelDensity: 1,

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -1263,7 +1263,7 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
    */
   private updateCachedValues(): void {
     const { ratio } = this.camera.getState();
-    this.cameraSizeRatio = Math.sqrt(ratio);
+    this.cameraSizeRatio = this.settings.getCameraSizeRatio(ratio);
   }
 
   /**---------------------------------------------------------------------------


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, node size changes non-linear with zoom level. The function for non-linearity is fixed `Math.sqrt(cameraRatio)`.  While this is fine for most cases, it prevents implementing WebGL programs and shaders which implement a different behavior.

## What is the new behavior?

The function for calculation the size of the node wrt the camera is made configurable in the settings. If unset, the current `Math.sqrt(cameraRatio)` function is used. Using this default a breaking change is prevented.

## Other information

The size calculation in the relevant node programs should be synced with this function. While this is not needed for the current programs, it allows for own programs to be used which use different ratio calculation, without needing to change the sigma.js library code.
