### PR TITLE
fix Graph type mismatch

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,8 @@
  * Various helper functions & classes used throughout the library.
  * @module
  */
-import Graph, { Attributes } from "graphology-types";
+import Graph from "graphology";
+import { Attributes } from "graphology-types";
 import isGraph from "graphology-utils/is-graph";
 import { CameraState, Coordinates, Dimensions, Extent, PlainObject } from "../types";
 import { multiply, identity, scale, rotate, translate, multiplyVec2 } from "./matrices";


### PR DESCRIPTION
The `Graph` type used in `src/sigma.ts` is imported from `graphology` which is not compatible with the one imported from `graphology-types` here.
See https://github.com/jacomyal/sigma.js/issues/1244.

## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

> **_NOTE:_** Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?

> **_NOTE:_** Describe the behavior or changes that are being added by this PR.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.
