### PR TITLE
Attempted fix at issue with sigma inside a shadow-DOM

### DIFF
--- a/src/core/captors/mouse.ts
+++ b/src/core/captors/mouse.ts
@@ -76,6 +76,7 @@ export default class MouseCaptor extends Captor<MouseCaptorEvents> {
     container.addEventListener("mousedown", this.handleDown, false);
     container.addEventListener("wheel", this.handleWheel, false);
     container.addEventListener("mouseout", this.handleOut, false);
+    container.addEventListener("mousemove", this.handleMove, false);
 
     document.addEventListener("mousemove", this.handleMove, false);
     document.addEventListener("mouseup", this.handleUp, false);
@@ -89,6 +90,7 @@ export default class MouseCaptor extends Captor<MouseCaptorEvents> {
     container.removeEventListener("mousedown", this.handleDown);
     container.removeEventListener("wheel", this.handleWheel);
     container.removeEventListener("mouseout", this.handleOut);
+    container.removeEventListener("mousemove", this.handleMove);
 
     document.removeEventListener("mousemove", this.handleMove);
     document.removeEventListener("mouseup", this.handleUp);


### PR DESCRIPTION
## Pull request type
Bugfix

## Current behavior
When sigma is placed inside a Shadow-DOM, you cannot hover or click nodes.
Here is a [CodeSandbox](https://codesandbox.io/s/shadow-dom-example-wudc0e?file=/index.ts) to demonstrate.

## New behavior
Now you can!

## Details
The reason this was happening (I believe) was that the `mousemove` event was bound to the document. This meant that if sigma was inside a Shadow-DOM, the event would be re-targeted to the shadow host instead, and thus the equality on this [line](https://github.com/jacomyal/sigma.js/blob/8838fe7d8ca473b3643257782134db678595f6ad/src/core/captors/mouse.ts#L221) would fail even when hovering over the container.

My solution was to add the `handleMove` event to the container as well. This fixes the problem because the event listener remains within the scope of the Shadow-DOM so the event doesn't get re-targeted. 

I kept the original listener bound to the document because it looks like that allows you to handle stage drag events even when the mouse is outside the container. However, this does mean that there are now some redundant events being triggered. When moving over the container, both the container-bound event and the document-bound event trigger, each emitting their own `mousemove` and `mousemovebody` events (though only the new container-bound events have the correct target when inside a shadow-dom). To solve this, we could potentially separate `mousemove` and `mousemovebody` into two different handlers, `mousemove` bound to the container and `mousemovebody` bound to the document. I attempted to do this myself, but it ended up being a more significant change than I anticipated and I don't think I am familiar enough with the codebase to avoid unintentionally messing up other things, so I ended up not submitting those changes.