### PR TITLE
Direction for missing "nodeProgramClasses" entry

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -783,7 +783,12 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
       if (typeof data.label === "string" && !data.hidden)
         this.labelGrid.add(node, data.size, this.framedGraphToViewport(data, { matrix: nullCameraMatrix }));
 
-      this.nodePrograms[data.type].process(data, data.hidden, nodesPerPrograms[data.type]++);
+      const nodeProgram = this.nodePrograms[data.type];
+      if (nodeProgram) {
+        nodeProgram.process(data, data.hidden, nodesPerPrograms[data.type]++);
+      } else {
+        console.error(`Node Program of type "${data.type}" specified by node, but not included in "nodeProgramClasses" field of Sigma configuration`);
+      }
 
       // Save the node in the highlighted set if needed
       if (data.highlighted && !data.hidden) this.highlightedNodes.add(node);


### PR DESCRIPTION
I copied an example project, and decided I didn't feel like copying over all the different `nodeProgramClasses`.  When I ran my project, I got a strange error with an untraceable call stack.  By adding this small check, no such confusion will ever have to happen again.

> main.ts:8 Uncaught TypeError: Cannot read properties of undefined (reading 'process')
>    at Sigma.process (main.ts:8:40)
>    at new Sigma (main.ts:8:40)
>    at SigmaSentimentGraph.initRenderer (SigmaGraph.view.ts:80:10)
>    at SentimentMatrix.view.ts:12:26

## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

> **_NOTE:_** Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?

> **_NOTE:_** Describe the behavior or changes that are being added by this PR.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.
