### PR TITLE
fix: parse alpha value of hex format

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -260,8 +260,9 @@ export function parseColor(val: string): RGBAColor {
       g = parseInt(val.charAt(3) + val.charAt(4), 16);
       b = parseInt(val.charAt(5) + val.charAt(6), 16);
     }
-
-    // TODO: parse hex with alpha?
+    if (val.length === 9) {
+      a = parseInt(val.charAt(7) + val.charAt(8), 16) / 255;
+    }
   }
 
   // Handling rgb notation


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Alpha values of hex colors are not parsed (e.g. `#ff000080`) - red with alpha=0.5

## What is the new behavior?
If alpha value if specified, it is parsed and used