### PR TITLE
Parameterize Sigma over the Graph type

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -147,9 +147,9 @@ export type SigmaEvents = SigmaStageEvents & SigmaNodeEvents & SigmaEdgeEvents &
  * @param {HTMLElement} container - DOM container in which to render.
  * @param {object}      settings  - Optional settings.
  */
-export default class Sigma extends TypedEventEmitter<SigmaEvents> {
+export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEmitter<SigmaEvents> {
   private settings: Settings;
-  private graph: Graph;
+  private graph: GraphType;
   private mouseCaptor: MouseCaptor;
   private touchCaptor: TouchCaptor;
   private container: HTMLElement;
@@ -200,7 +200,7 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
 
   private camera: Camera;
 
-  constructor(graph: Graph, container: HTMLElement, settings: Partial<Settings> = {}) {
+  constructor(graph: GraphType, container: HTMLElement, settings: Partial<Settings> = {}) {
     super();
 
     this.settings = assign<Settings>({}, DEFAULT_SETTINGS, settings);
@@ -1297,7 +1297,7 @@ export default class Sigma extends TypedEventEmitter<SigmaEvents> {
    *
    * @return {Graph}
    */
-  getGraph(): Graph {
+  getGraph(): GraphType {
     return this.graph;
   }
 


### PR DESCRIPTION
This allows for getting the Graph as an object with typed attributes,
allowing for type-safely accessing properties through it.

## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

You currently have to create a subclass to put custom data on nodes/edges and have it be type safe.

## What is the new behavior?

It's now possible to just specify the exact graph type as a type parameter and it will work.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.
