### PR TITLE
fix all touch events shifted if container not at 0,0

### DIFF
--- a/src/core/captors/captor.ts
+++ b/src/core/captors/captor.ts
@@ -6,6 +6,8 @@
 import { Coordinates, MouseCoords, TouchCoords, WheelCoords, TypedEventEmitter, EventsMapping } from "../../types";
 import Sigma from "../../sigma";
 
+export type FakeSigmaMouseEvent = MouseEvent & { isFakeSigmaMouseEvent?: true };
+
 /**
  * Captor utils functions
  * ======================
@@ -24,10 +26,15 @@ import Sigma from "../../sigma";
 export function getPosition(e: MouseEvent | Touch, dom: HTMLElement): Coordinates {
   const bbox = dom.getBoundingClientRect();
 
-  return {
-    x: e.clientX - bbox.left,
-    y: e.clientY - bbox.top,
-  };
+  return (e as FakeSigmaMouseEvent).isFakeSigmaMouseEvent ?
+    {
+      x: e.clientX,
+      y: e.clientY
+    } :
+    {
+      x: e.clientX - bbox.left,
+      y: e.clientY - bbox.top,
+    };
 }
 
 /**

--- a/src/core/captors/touch.ts
+++ b/src/core/captors/touch.ts
@@ -6,14 +6,12 @@
  * @module
  */
 import { CameraState, Coordinates, Dimensions, TouchCoords } from "../../types";
-import Captor, { getPosition, getTouchCoords, getTouchesArray } from "./captor";
+import Captor, { getPosition, getTouchCoords, getTouchesArray, FakeSigmaMouseEvent } from "./captor";
 import Sigma from "../../sigma";
 
 const DRAG_TIMEOUT = 200;
 const TOUCH_INERTIA_RATIO = 3;
 const TOUCH_INERTIA_DURATION = 200;
-
-export type FakeSigmaMouseEvent = MouseEvent & { isFakeSigmaMouseEvent?: true };
 
 /**
  * Event types.

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -40,7 +40,8 @@ import { edgeLabelsToDisplayFromNodes, LabelGrid } from "./core/labels";
 import { Settings, DEFAULT_SETTINGS, validateSettings } from "./settings";
 import { INodeProgram } from "./rendering/webgl/programs/common/node";
 import { IEdgeProgram } from "./rendering/webgl/programs/common/edge";
-import TouchCaptor, { FakeSigmaMouseEvent } from "./core/captors/touch";
+import TouchCaptor from "./core/captors/touch";
+import { FakeSigmaMouseEvent } from "./core/captors/captor";
 import { identity, multiplyVec2 } from "./utils/matrices";
 import { doEdgeCollideWithPoint, isPixelColored } from "./utils/edge-collisions";
 


### PR DESCRIPTION
This fixes touches positions for all kind of events and not only click ones as was doing #1242 
Tested with the mouse-manipulations example for clicks, double clicks, drag, rotate and pinch

(should close #1256)

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

> **_NOTE:_** Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?

> **_NOTE:_** Describe the behavior or changes that are being added by this PR.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.
