### PR TITLE
Adding hoverNodeProgramClasses setting

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,9 +5,9 @@
  * The list of settings and some handy functions.
  * @module
  */
-
 import { Attributes } from "graphology-types";
 
+import { assign } from "./utils";
 import drawLabel from "./rendering/canvas/label";
 import drawHover from "./rendering/canvas/hover";
 import drawEdgeLabel from "./rendering/canvas/edge-label";
@@ -17,19 +17,6 @@ import LineEdgeProgram from "./rendering/webgl/programs/edge";
 import ArrowEdgeProgram from "./rendering/webgl/programs/edge.arrow";
 import { EdgeProgramConstructor } from "./rendering/webgl/programs/common/edge";
 import { NodeProgramConstructor } from "./rendering/webgl/programs/common/node";
-
-export function validateSettings(settings: Settings): void {
-  if (typeof settings.labelDensity !== "number" || settings.labelDensity < 0) {
-    throw new Error("Settings: invalid `labelDensity`. Expecting a positive number.");
-  }
-
-  const { minCameraRatio, maxCameraRatio } = settings;
-  if (typeof minCameraRatio === "number" && typeof maxCameraRatio === "number" && maxCameraRatio < minCameraRatio) {
-    throw new Error(
-      "Settings: invalid camera ratio boundaries. Expecting `maxCameraRatio` to be greater than `minCameraRatio`.",
-    );
-  }
-}
 
 /**
  * Sigma.js settings
@@ -130,12 +117,38 @@ export const DEFAULT_SETTINGS: Settings = {
   allowInvalidContainer: false,
 
   // Program classes
-  nodeProgramClasses: {
-    circle: CircleNodeProgram,
-  },
+  nodeProgramClasses: {},
   nodeHoverProgramClasses: {},
-  edgeProgramClasses: {
-    arrow: ArrowEdgeProgram,
-    line: LineEdgeProgram,
-  },
+  edgeProgramClasses: {},
 };
+
+export const DEFAULT_NODE_PROGRAM_CLASSES = {
+  circle: CircleNodeProgram,
+};
+
+export const DEFAULT_EDGE_PROGRAM_CLASSES = {
+  arrow: ArrowEdgeProgram,
+  line: LineEdgeProgram,
+};
+
+export function validateSettings(settings: Settings): void {
+  if (typeof settings.labelDensity !== "number" || settings.labelDensity < 0) {
+    throw new Error("Settings: invalid `labelDensity`. Expecting a positive number.");
+  }
+
+  const { minCameraRatio, maxCameraRatio } = settings;
+  if (typeof minCameraRatio === "number" && typeof maxCameraRatio === "number" && maxCameraRatio < minCameraRatio) {
+    throw new Error(
+      "Settings: invalid camera ratio boundaries. Expecting `maxCameraRatio` to be greater than `minCameraRatio`.",
+    );
+  }
+}
+
+export function resolveSettings(settings: Partial<Settings>): Settings {
+  const resolvedSettings = assign({}, DEFAULT_SETTINGS, settings);
+
+  resolvedSettings.nodeProgramClasses = assign({}, DEFAULT_NODE_PROGRAM_CLASSES, resolvedSettings.nodeProgramClasses);
+  resolvedSettings.edgeProgramClasses = assign({}, DEFAULT_EDGE_PROGRAM_CLASSES, resolvedSettings.edgeProgramClasses);
+
+  return resolvedSettings;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -77,8 +77,9 @@ export interface Settings {
   allowInvalidContainer: boolean;
 
   // Program classes
-  nodeProgramClasses: { [key: string]: NodeProgramConstructor };
-  edgeProgramClasses: { [key: string]: EdgeProgramConstructor };
+  nodeProgramClasses: { [type: string]: NodeProgramConstructor };
+  hoverNodeProgramClasses: { [type: string]: NodeProgramConstructor };
+  edgeProgramClasses: { [type: string]: EdgeProgramConstructor };
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -132,6 +133,7 @@ export const DEFAULT_SETTINGS: Settings = {
   nodeProgramClasses: {
     circle: CircleNodeProgram,
   },
+  hoverNodeProgramClasses: {},
   edgeProgramClasses: {
     arrow: ArrowEdgeProgram,
     line: LineEdgeProgram,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -78,7 +78,7 @@ export interface Settings {
 
   // Program classes
   nodeProgramClasses: { [type: string]: NodeProgramConstructor };
-  hoverNodeProgramClasses: { [type: string]: NodeProgramConstructor };
+  nodeHoverProgramClasses: { [type: string]: NodeProgramConstructor };
   edgeProgramClasses: { [type: string]: EdgeProgramConstructor };
 }
 
@@ -133,7 +133,7 @@ export const DEFAULT_SETTINGS: Settings = {
   nodeProgramClasses: {
     circle: CircleNodeProgram,
   },
-  hoverNodeProgramClasses: {},
+  nodeHoverProgramClasses: {},
   edgeProgramClasses: {
     arrow: ArrowEdgeProgram,
     line: LineEdgeProgram,

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -27,7 +27,6 @@ import {
   getPixelRatio,
   createNormalizationFunction,
   NormalizationFunction,
-  assign,
   cancelFrame,
   matrixFromCamera,
   requestFrame,
@@ -37,7 +36,7 @@ import {
   graphExtent,
 } from "./utils";
 import { edgeLabelsToDisplayFromNodes, LabelGrid } from "./core/labels";
-import { Settings, DEFAULT_SETTINGS, validateSettings } from "./settings";
+import { Settings, validateSettings, resolveSettings } from "./settings";
 import { INodeProgram } from "./rendering/webgl/programs/common/node";
 import { IEdgeProgram } from "./rendering/webgl/programs/common/edge";
 import TouchCaptor, { FakeSigmaMouseEvent } from "./core/captors/touch";
@@ -203,7 +202,8 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
   constructor(graph: GraphType, container: HTMLElement, settings: Partial<Settings> = {}) {
     super();
 
-    this.settings = assign<Settings>({}, DEFAULT_SETTINGS, settings);
+    // Resolving settings
+    this.settings = resolveSettings(settings);
 
     // Validating
     validateSettings(this.settings);

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -195,7 +195,7 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
 
   // Programs
   private nodePrograms: { [key: string]: INodeProgram } = {};
-  private hoverNodePrograms: { [key: string]: INodeProgram } = {};
+  private nodeHoverPrograms: { [key: string]: INodeProgram } = {};
   private edgePrograms: { [key: string]: IEdgeProgram } = {};
 
   private camera: Camera;
@@ -236,12 +236,12 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
       const NodeProgramClass = this.settings.nodeProgramClasses[type];
       this.nodePrograms[type] = new NodeProgramClass(this.webGLContexts.nodes, this);
 
-      let HoverNodeProgramClass = NodeProgramClass;
-      if (type in this.settings.hoverNodeProgramClasses) {
-        HoverNodeProgramClass = this.settings.hoverNodeProgramClasses[type];
+      let NodeHoverProgram = NodeProgramClass;
+      if (type in this.settings.nodeHoverProgramClasses) {
+        NodeHoverProgram = this.settings.nodeHoverProgramClasses[type];
       }
 
-      this.hoverNodePrograms[type] = new HoverNodeProgramClass(this.webGLContexts.hoverNodes, this);
+      this.nodeHoverPrograms[type] = new NodeHoverProgram(this.webGLContexts.hoverNodes, this);
     }
     for (const type in this.settings.edgeProgramClasses) {
       const EdgeProgramClass = this.settings.edgeProgramClasses[type];
@@ -1147,21 +1147,21 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
       nodesPerPrograms[type] = (nodesPerPrograms[type] || 0) + 1;
     });
     // 2. Allocate for each type for the proper number of nodes
-    for (const type in this.hoverNodePrograms) {
-      this.hoverNodePrograms[type].allocate(nodesPerPrograms[type] || 0);
+    for (const type in this.nodeHoverPrograms) {
+      this.nodeHoverPrograms[type].allocate(nodesPerPrograms[type] || 0);
       // Also reset count, to use when rendering:
       nodesPerPrograms[type] = 0;
     }
     // 3. Process all nodes to render:
     nodesToRender.forEach((node) => {
       const data = this.nodeDataCache[node];
-      this.hoverNodePrograms[data.type].process(data, data.hidden, nodesPerPrograms[data.type]++);
+      this.nodeHoverPrograms[data.type].process(data, data.hidden, nodesPerPrograms[data.type]++);
     });
     // 4. Clear hovered nodes layer:
     this.webGLContexts.hoverNodes.clear(this.webGLContexts.hoverNodes.COLOR_BUFFER_BIT);
     // 5. Render:
-    for (const type in this.hoverNodePrograms) {
-      const program = this.hoverNodePrograms[type];
+    for (const type in this.nodeHoverPrograms) {
+      const program = this.nodeHoverPrograms[type];
 
       program.bind();
       program.bufferData();

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -235,7 +235,13 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
     for (const type in this.settings.nodeProgramClasses) {
       const NodeProgramClass = this.settings.nodeProgramClasses[type];
       this.nodePrograms[type] = new NodeProgramClass(this.webGLContexts.nodes, this);
-      this.hoverNodePrograms[type] = new NodeProgramClass(this.webGLContexts.hoverNodes, this);
+
+      let HoverNodeProgramClass = NodeProgramClass;
+      if (type in this.settings.hoverNodeProgramClasses) {
+        HoverNodeProgramClass = this.settings.hoverNodeProgramClasses[type];
+      }
+
+      this.hoverNodePrograms[type] = new HoverNodeProgramClass(this.webGLContexts.hoverNodes, this);
     }
     for (const type in this.settings.edgeProgramClasses) {
       const EdgeProgramClass = this.settings.edgeProgramClasses[type];


### PR DESCRIPTION
This new setting enables us to select different node programs for highligh/hovering. This is useful in some scenario like a heatmap when you have a "halo" program rendering nodes with a blurry background and you don't want the blurry background to appear over the rest when hovering the node for instance.

Some open questions:

1. Should we make stricter types to ensure nodeProgramClasses/hoverNodeProgramClasses etc. to respect some dependencies and make sure we can restrict also `defaultNodeType` for instance (this could prove too strict and bothersome for the user though, since it cannot be done without adding a "tartine" of generics).
2. Should we change the settings semantics so that nodeProgramClasses etc. are passed as a supplementary object to merge with the defaults one? Oftentimes, when you just need to add a single custom program for some nodes/edges, it is somewhat cumbersome to be required to import default programs to "reconstruct" the default one with your addition.
3. I followed the current internal naming of the Sigma class for `hoverNodeProgramClasses`. Should we call it `nodeHoverProgramClasses`? I don't have a strong opinon on this.

Fixes #1217 