### PR TITLE
trigger mouseup even after a move

### DIFF
--- a/src/core/captors/touch.ts
+++ b/src/core/captors/touch.ts
@@ -120,9 +120,12 @@ export default class TouchCaptor extends Captor<TouchCaptorEvents> {
     // Prevent default to avoid default browser behaviors...
     e.preventDefault();
     // ...but simulate mouse behavior anyway, to get the MouseCaptor working as well:
-    if (e.touches.length === 0 && this.lastTouches && this.lastTouches.length && !this.hasMoved) {
+    if (e.touches.length === 0 && this.lastTouches && this.lastTouches.length) {
       this.dispatchRelatedMouseEvent("mouseup", e, this.lastTouches[0], document);
-      this.dispatchRelatedMouseEvent("click", e, this.lastTouches[0]);
+      // ... and only click if no move was made
+      if (!this.hasMoved) {
+        this.dispatchRelatedMouseEvent("click", e, this.lastTouches[0]);
+      }
     }
 
     if (this.movingTimeout) {


### PR DESCRIPTION
in order to always reset isMouseDown to false whenever a touch is stopped.

only click should be blocked if there was a touch move.

## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
