### PR TITLE
New program class proposition

### DIFF
--- a/src/rendering/webgl/programs/common/proposition.ts
+++ b/src/rendering/webgl/programs/common/proposition.ts
@@ -130,7 +130,7 @@ export abstract class NodeProgram implements AbstractNodeProgram {
     let i = offset * this.STRIDE;
 
     // NOTE: dealing with the hidden issues automatically
-    if (!hidden) return this.processItem(this.array, i, data);
+    if (!hidden) return this.processShownItem(this.array, i, data);
 
     for (let l = i + this.STRIDE; i < l; i++) {
       this.array[i] = 0;
@@ -140,7 +140,7 @@ export abstract class NodeProgram implements AbstractNodeProgram {
   // NOTE: I chose to explicitly pass members of the class to the methods
   // such as this.gl etc. but this could be dropped, I just feel it makes
   // the class easier to implement, regarding our usual practice
-  abstract processItem(array: Float32Array, i: number, data: NodeDisplayData): void;
+  abstract processShownItem(array: Float32Array, i: number, data: NodeDisplayData): void;
   abstract setUniforms(
     gl: WebGLRenderingContext,
     locations: Record<string, WebGLUniformLocation>,
@@ -180,7 +180,7 @@ export class NodeFastProgram extends NodeProgram {
     { name: "a_angle", size: 1, type: FLOAT },
   ];
 
-  processItem(array: Float32Array, i: number, data: NodeDisplayData): void {
+  processShownItem(array: Float32Array, i: number, data: NodeDisplayData): void {
     const color = floatColor(data.color);
 
     array[i++] = data.x;

--- a/src/rendering/webgl/programs/common/proposition.ts
+++ b/src/rendering/webgl/programs/common/proposition.ts
@@ -141,7 +141,11 @@ export abstract class NodeProgram implements AbstractNodeProgram {
   // such as this.gl etc. but this could be dropped, I just feel it makes
   // the class easier to implement, regarding our usual practice
   abstract processItem(array: Float32Array, i: number, data: NodeDisplayData): void;
-  abstract setUniforms(gl: WebGLRenderingContext, params: RenderParams): void;
+  abstract setUniforms(
+    gl: WebGLRenderingContext,
+    locations: Record<string, WebGLUniformLocation>,
+    params: RenderParams,
+  ): void;
   abstract draw(gl: WebGLRenderingContext, params: RenderParams): void;
 
   render(params: RenderParams): void {
@@ -150,7 +154,7 @@ export abstract class NodeProgram implements AbstractNodeProgram {
     this.bind();
     this.bufferData();
     this.gl.useProgram(this.program);
-    this.setUniforms(this.gl, params);
+    this.setUniforms(this.gl, this.uniformLocations, params);
     this.draw(this.gl, params);
   }
 }
@@ -185,10 +189,14 @@ export class NodeFastProgram extends NodeProgram {
     array[i] = color;
   }
 
-  setUniforms(gl: WebGLRenderingContext, params: RenderParams): void {
-    gl.uniformMatrix3fv(this.uniformLocations.u_matrix, false, params.matrix);
-    gl.uniform1f(this.uniformLocations.u_sqrtZoomRatioLocation, Math.sqrt(params.ratio));
-    gl.uniform1f(this.uniformLocations.u_correctionRatioLocation, params.correctionRatio);
+  setUniforms(
+    gl: WebGLRenderingContext,
+    { u_matrix, u_sqrtZoomRatio, u_correctionRatio }: Record<string, WebGLUniformLocation>,
+    params: RenderParams,
+  ): void {
+    gl.uniformMatrix3fv(u_matrix, false, params.matrix);
+    gl.uniform1f(u_sqrtZoomRatio, Math.sqrt(params.ratio));
+    gl.uniform1f(u_correctionRatio, params.correctionRatio);
   }
 
   draw(gl: WebGLRenderingContext, _params: RenderParams): void {

--- a/src/rendering/webgl/programs/common/proposition.ts
+++ b/src/rendering/webgl/programs/common/proposition.ts
@@ -24,7 +24,7 @@ export interface AttributeSpecification {
   normalized?: boolean;
 }
 
-export abstract class NodeProgram<Uniform extends string> implements AbstractNodeProgram {
+export abstract class NodeProgram<Uniform extends string = string> implements AbstractNodeProgram {
   abstract readonly VERTICES: number;
   abstract readonly ARRAY_ITEMS_PER_VERTEX: number;
   abstract readonly VERTEX_SHADER_SOURCE: string;

--- a/src/rendering/webgl/programs/common/proposition.ts
+++ b/src/rendering/webgl/programs/common/proposition.ts
@@ -1,0 +1,114 @@
+import { loadVertexShader, loadFragmentShader, loadProgram } from "../../shaders/utils";
+
+export type AttributeSpecification = {
+  name: string;
+  size: number;
+  type: "float" | "unsigned_byte";
+};
+
+export abstract class NodeProgram {
+  abstract readonly VERTICES: number;
+  abstract readonly ARRAY_ITEMS_PER_VERTEX: number;
+  abstract readonly VERTEX_SHADER_SOURCE: string;
+  abstract readonly FRAGMENT_SHADER_SOURCE: string;
+  abstract readonly UNIFORMS: Array<string>;
+  abstract readonly ATTRIBUTES: Array<AttributeSpecification>;
+
+  gl: WebGLRenderingContext;
+  buffer: WebGLBuffer;
+  array: Float32Array = new Float32Array();
+  vertexShader: WebGLShader;
+  fragmentShader: WebGLShader;
+  program: WebGLProgram;
+  uniformLocations: Record<string, WebGLUniformLocation> = {};
+  attributeLocations: Record<string, GLint> = {};
+  capacity = 0;
+  vertices = 0;
+
+  constructor(gl: WebGLRenderingContext) {
+    this.gl = gl;
+
+    const buffer = gl.createBuffer();
+    if (buffer === null) throw new Error("Program: error while creating the webgl buffer.");
+    this.buffer = buffer;
+
+    // Not doing this in the constructor because of abstract members
+    const [vertexShader, fragmentShader, program] = this.loadProgram();
+
+    this.vertexShader = vertexShader;
+    this.fragmentShader = fragmentShader;
+    this.program = program;
+
+    this.initLocations();
+    this.bind();
+  }
+
+  private loadProgram() {
+    const vertexShader = loadVertexShader(this.gl, this.VERTEX_SHADER_SOURCE);
+    const fragmentShader = loadFragmentShader(this.gl, this.FRAGMENT_SHADER_SOURCE);
+    const program = loadProgram(this.gl, [this.vertexShader, this.fragmentShader]);
+
+    return [vertexShader, fragmentShader, program];
+  }
+
+  private initLocations() {
+    this.UNIFORMS.forEach((uniformName) => {
+      const location = this.gl.getUniformLocation(this.program, uniformName);
+      if (location === null) throw new Error(`Program: error while getting location for uniform "${uniformName}".`);
+      this.uniformLocations[uniformName] = location;
+    });
+
+    for (const attributeName in this.ATTRIBUTES) {
+      const location = this.gl.getAttribLocation(this.program, attributeName);
+      if (location === -1) throw new Error(`Program: error while getting location for attribute "${attributeName}".`);
+      this.attributeLocations[attributeName] = location;
+    }
+  }
+
+  bind(): void {
+    const gl = this.gl;
+
+    for (const attributeName in this.ATTRIBUTES) {
+      gl.enableVertexAttribArray(this.attributeLocations[attributeName]);
+    }
+
+    // TODO: strides
+  }
+
+  bufferData(): void {
+    const gl = this.gl;
+    gl.bufferData(gl.ARRAY_BUFFER, this.array, gl.DYNAMIC_DRAW);
+  }
+
+  allocate(capacity: number): void {
+    this.capacity = capacity;
+    this.vertices = this.VERTICES * capacity;
+    this.array = new Float32Array(this.vertices * this.ARRAY_ITEMS_PER_VERTEX);
+  }
+
+  hasNothingToRender(): boolean {
+    return this.array.length === 0;
+  }
+
+  // TODO: process, processAll, render, draw
+}
+
+// -------
+// EXAMPLE
+// -------
+import vertexShaderSource from "../shaders/node.vert.glsl";
+import fragmentShaderSource from "../shaders/node.frag.glsl";
+
+export class NodeFastProgram extends NodeProgram {
+  readonly VERTICES = 1;
+  readonly ARRAY_ITEMS_PER_VERTEX = 5;
+  readonly VERTEX_SHADER_SOURCE = vertexShaderSource;
+  readonly FRAGMENT_SHADER_SOURCE = fragmentShaderSource;
+  readonly UNIFORMS = ["u_matrix", "u_sqrtZoomRatio", "u_correctionRatio"];
+  readonly ATTRIBUTES = [
+    { name: "a_position", size: 2, type: "float" as const },
+    { name: "a_size", size: 1, type: "float" as const },
+    { name: "a_color", size: 4, type: "unsigned_byte" as const },
+    { name: "a_angle", size: 1, type: "float" as const },
+  ];
+}

--- a/src/rendering/webgl/programs/common/proposition.ts
+++ b/src/rendering/webgl/programs/common/proposition.ts
@@ -24,12 +24,12 @@ export interface AttributeSpecification {
   normalized?: boolean;
 }
 
-export abstract class NodeProgram implements AbstractNodeProgram {
+export abstract class NodeProgram<Uniform extends string> implements AbstractNodeProgram {
   abstract readonly VERTICES: number;
   abstract readonly ARRAY_ITEMS_PER_VERTEX: number;
   abstract readonly VERTEX_SHADER_SOURCE: string;
   abstract readonly FRAGMENT_SHADER_SOURCE: string;
-  abstract readonly UNIFORMS: Array<string>;
+  abstract readonly UNIFORMS: ReadonlyArray<Uniform>;
   abstract readonly ATTRIBUTES: Array<AttributeSpecification>;
   STRIDE: number = 0;
 
@@ -44,7 +44,7 @@ export abstract class NodeProgram implements AbstractNodeProgram {
   vertexShader: WebGLShader;
   fragmentShader: WebGLShader;
   program: WebGLProgram;
-  uniformLocations: Record<string, WebGLUniformLocation> = {};
+  uniformLocations = {} as Record<Uniform, WebGLUniformLocation>;
   attributeLocations: Record<string, GLint> = {};
   capacity = 0;
   verticesCount = 0;
@@ -191,12 +191,14 @@ import fragmentShaderSource from "../shaders/node.frag.glsl";
 
 const { FLOAT, UNSIGNED_BYTE } = WebGLRenderingContext;
 
-export class NodeFastProgram extends NodeProgram {
+const UNIFORMS = ["u_matrix", "u_sqrtZoomRatio", "u_correctionRatio"] as const;
+
+export class NodeFastProgram extends NodeProgram<typeof UNIFORMS[number]> {
   readonly VERTICES = 1;
   readonly ARRAY_ITEMS_PER_VERTEX = 5;
   readonly VERTEX_SHADER_SOURCE = vertexShaderSource;
   readonly FRAGMENT_SHADER_SOURCE = fragmentShaderSource;
-  readonly UNIFORMS = ["u_matrix", "u_sqrtZoomRatio", "u_correctionRatio"];
+  readonly UNIFORMS = UNIFORMS;
   readonly ATTRIBUTES = [
     { name: "a_position", size: 2, type: FLOAT },
     { name: "a_size", size: 1, type: FLOAT },

--- a/src/rendering/webgl/programs/common/proposition.ts
+++ b/src/rendering/webgl/programs/common/proposition.ts
@@ -47,7 +47,7 @@ export abstract class NodeProgram implements AbstractNodeProgram {
   capacity = 0;
   verticesCount = 0;
 
-  constructor(gl: WebGLRenderingContext) {
+  constructor(gl: WebGLRenderingContext, _renderer: Sigma) {
     this.gl = gl;
 
     const buffer = gl.createBuffer();

--- a/src/rendering/webgl/programs/common/proposition.ts
+++ b/src/rendering/webgl/programs/common/proposition.ts
@@ -1,18 +1,40 @@
+import type Sigma from "../../../../sigma";
+import type { NodeDisplayData } from "../../../../types";
+import type { RenderParams } from "./program";
+import { floatColor } from "../../../../utils";
 import { loadVertexShader, loadFragmentShader, loadProgram } from "../../shaders/utils";
+
+// ---------------------------------------------------------------------
+// Minimum viable class to implement for your program to work with Sigma
+// ---------------------------------------------------------------------
+export abstract class AbstractNodeProgram {
+  constructor(_gl: WebGLRenderingContext, _renderer: Sigma) {}
+  abstract reallocate(capacity: number): void;
+  abstract process(offset: number, data: NodeDisplayData, hidden?: boolean): void;
+  abstract render(params: RenderParams): void;
+}
+
+// --------------------------
+// Typical Sigma node program
+// --------------------------
+
+// TODO: edge vs. node
+// TODO: indices
 
 export type AttributeSpecification = {
   name: string;
   size: number;
-  type: "float" | "unsigned_byte";
+  type: number;
 };
 
-export abstract class NodeProgram {
+export abstract class NodeProgram implements AbstractNodeProgram {
   abstract readonly VERTICES: number;
   abstract readonly ARRAY_ITEMS_PER_VERTEX: number;
   abstract readonly VERTEX_SHADER_SOURCE: string;
   abstract readonly FRAGMENT_SHADER_SOURCE: string;
   abstract readonly UNIFORMS: Array<string>;
   abstract readonly ATTRIBUTES: Array<AttributeSpecification>;
+  STRIDE: number = 0;
 
   gl: WebGLRenderingContext;
   buffer: WebGLBuffer;
@@ -23,7 +45,7 @@ export abstract class NodeProgram {
   uniformLocations: Record<string, WebGLUniformLocation> = {};
   attributeLocations: Record<string, GLint> = {};
   capacity = 0;
-  vertices = 0;
+  verticesCount = 0;
 
   constructor(gl: WebGLRenderingContext) {
     this.gl = gl;
@@ -39,6 +61,7 @@ export abstract class NodeProgram {
     this.fragmentShader = fragmentShader;
     this.program = program;
 
+    this.initMembers();
     this.initLocations();
     this.bind();
   }
@@ -49,6 +72,10 @@ export abstract class NodeProgram {
     const program = loadProgram(this.gl, [this.vertexShader, this.fragmentShader]);
 
     return [vertexShader, fragmentShader, program];
+  }
+
+  private initMembers() {
+    this.STRIDE = this.VERTICES * this.ARRAY_ITEMS_PER_VERTEX;
   }
 
   private initLocations() {
@@ -65,32 +92,67 @@ export abstract class NodeProgram {
     }
   }
 
-  bind(): void {
+  private bind(): void {
     const gl = this.gl;
 
     for (const attributeName in this.ATTRIBUTES) {
       gl.enableVertexAttribArray(this.attributeLocations[attributeName]);
     }
 
-    // TODO: strides
+    // TODO: vertexAttribPointer etc. that strides automagically (I don't want
+    // to manage this by hand anymore).
   }
 
-  bufferData(): void {
+  private bufferData(): void {
     const gl = this.gl;
     gl.bufferData(gl.ARRAY_BUFFER, this.array, gl.DYNAMIC_DRAW);
   }
 
-  allocate(capacity: number): void {
+  reallocate(capacity: number): void {
+    // NOTE: we should test here capacity changes and assess whether arrays
+    // must be dynamically reallocated or not. This makes the keepArrays
+    // argument of renderer.process useless and we can drop the
+    // soft process vs. hard process difference which should simplify the
+    // renderer's lifecycle.
+
+    if (capacity === this.capacity) return;
+
     this.capacity = capacity;
-    this.vertices = this.VERTICES * capacity;
-    this.array = new Float32Array(this.vertices * this.ARRAY_ITEMS_PER_VERTEX);
+    this.verticesCount = this.VERTICES * capacity;
+    this.array = new Float32Array(this.verticesCount * this.ARRAY_ITEMS_PER_VERTEX);
   }
 
   hasNothingToRender(): boolean {
     return this.array.length === 0;
   }
 
-  // TODO: process, processAll, render, draw
+  process(offset: number, data: NodeDisplayData, hidden?: boolean): void {
+    let i = offset * this.STRIDE;
+
+    // NOTE: dealing with the hidden issues automatically
+    if (!hidden) return this.processItem(this.array, i, data);
+
+    for (let l = i + this.STRIDE; i < l; i++) {
+      this.array[i] = 0;
+    }
+  }
+
+  // NOTE: I chose to explicitly pass members of the class to the methods
+  // such as this.gl etc. but this could be dropped, I just feel it makes
+  // the class easier to implement, regarding our usual practice
+  abstract processItem(array: Float32Array, i: number, data: NodeDisplayData): void;
+  abstract setUniforms(gl: WebGLRenderingContext, params: RenderParams): void;
+  abstract draw(gl: WebGLRenderingContext, params: RenderParams): void;
+
+  render(params: RenderParams): void {
+    if (this.hasNothingToRender()) return;
+
+    this.bind();
+    this.bufferData();
+    this.gl.useProgram(this.program);
+    this.setUniforms(this.gl, params);
+    this.draw(this.gl, params);
+  }
 }
 
 // -------
@@ -99,6 +161,8 @@ export abstract class NodeProgram {
 import vertexShaderSource from "../shaders/node.vert.glsl";
 import fragmentShaderSource from "../shaders/node.frag.glsl";
 
+const { FLOAT, UNSIGNED_BYTE } = WebGLRenderingContext;
+
 export class NodeFastProgram extends NodeProgram {
   readonly VERTICES = 1;
   readonly ARRAY_ITEMS_PER_VERTEX = 5;
@@ -106,9 +170,28 @@ export class NodeFastProgram extends NodeProgram {
   readonly FRAGMENT_SHADER_SOURCE = fragmentShaderSource;
   readonly UNIFORMS = ["u_matrix", "u_sqrtZoomRatio", "u_correctionRatio"];
   readonly ATTRIBUTES = [
-    { name: "a_position", size: 2, type: "float" as const },
-    { name: "a_size", size: 1, type: "float" as const },
-    { name: "a_color", size: 4, type: "unsigned_byte" as const },
-    { name: "a_angle", size: 1, type: "float" as const },
+    { name: "a_position", size: 2, type: FLOAT },
+    { name: "a_size", size: 1, type: FLOAT },
+    { name: "a_color", size: 4, type: UNSIGNED_BYTE },
+    { name: "a_angle", size: 1, type: FLOAT },
   ];
+
+  processItem(array: Float32Array, i: number, data: NodeDisplayData): void {
+    const color = floatColor(data.color);
+
+    array[i++] = data.x;
+    array[i++] = data.y;
+    array[i++] = data.size;
+    array[i] = color;
+  }
+
+  setUniforms(gl: WebGLRenderingContext, params: RenderParams): void {
+    gl.uniformMatrix3fv(this.uniformLocations.u_matrix, false, params.matrix);
+    gl.uniform1f(this.uniformLocations.u_sqrtZoomRatioLocation, Math.sqrt(params.ratio));
+    gl.uniform1f(this.uniformLocations.u_correctionRatioLocation, params.correctionRatio);
+  }
+
+  draw(gl: WebGLRenderingContext, _params: RenderParams): void {
+    gl.drawArrays(gl.TRIANGLES, 0, this.verticesCount);
+  }
 }

--- a/src/rendering/webgl/programs/common/proposition.ts
+++ b/src/rendering/webgl/programs/common/proposition.ts
@@ -36,6 +36,7 @@ export abstract class NodeProgram implements AbstractNodeProgram {
   abstract readonly ATTRIBUTES: Array<AttributeSpecification>;
   STRIDE: number = 0;
 
+  renderer: Sigma;
   gl: WebGLRenderingContext;
   buffer: WebGLBuffer;
   array: Float32Array = new Float32Array();
@@ -47,8 +48,9 @@ export abstract class NodeProgram implements AbstractNodeProgram {
   capacity = 0;
   verticesCount = 0;
 
-  constructor(gl: WebGLRenderingContext, _renderer: Sigma) {
+  constructor(gl: WebGLRenderingContext, renderer: Sigma) {
     this.gl = gl;
+    this.renderer = renderer;
 
     const buffer = gl.createBuffer();
     if (buffer === null) throw new Error("Program: error while creating the webgl buffer.");


### PR DESCRIPTION
@jacomyal, since we are discussing about breaking changes, this PR presents a proposition of new classes for sigma's webgl programs. Programs are currently very repetitive, with a lot of boilerplate code, and quite hard to maintain frankly and I feel we can do better.

The code added to this PR presents a 3 classes solution:

1. An abstract class that defines what API Sigma expects from a webgl program to be able to do its work. It is very short and can be reimplemented by anyone who has different needs  than ours on how to handle webgl code. You basically need to implement a constructor, a reallocate, a process and a render method and you are good to go since sigma's renderer does not need to use anything more.
2. An semi-abstract class that encapuslates our webgl practices completely.
3. An example of program for `node.fast` that extends and implements `2.`. The code is therefore quite barebones, compared to what we have now, and should be way easier to maintain since all of the repetitive/boring logic we used to duplicate each time is now safely encapsulated by `2.` 

I feel this could be a good thing because programs could then be 1. more manageable and maintainable (it is now very easy to add/modify attributes and uniforms for instance without needing to edit a lot of boilerplate code) 2. prevent some typical footguns such as forgetting about hidden elements or failing to stride vertexAttribPointer calls correctly. 3. Make some space for the upcoming hitbox/collision function proposals.

The PR also draw some amelioration to the `allocate` methods that could enable us to drop the soft vs. hard process technicality of the renderer (which should simplify the lifecyle) by making the program responsible for dynamic memory allocation if required (for instance, if the ask a program to reallocate the same capacity, the program will decide itself not to create a new array or resize it based on some heuristics if we need to add/drop some items). This makes the `keepArrays` argument of `process` useless which is good. Admittedly, we can also implement this without considering this PR if it does not make it.

That's it. Tell me what you think.

