### PR TITLE
EdgeRectangleProgram contemplations

### DIFF
--- a/src/rendering/webgl/shaders/edge.rectangle.frag.glsl
+++ b/src/rendering/webgl/shaders/edge.rectangle.frag.glsl
@@ -4,7 +4,7 @@ varying vec4 v_color;
 varying vec2 v_normal;
 varying float v_thickness;
 
-const float feather = 0.001;
+const float feather = 0.7;
 const vec4 transparent = vec4(0.0, 0.0, 0.0, 0.0);
 
 void main(void) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,7 +14,7 @@ import drawEdgeLabel from "./rendering/canvas/edge-label";
 import { EdgeDisplayData, NodeDisplayData } from "./types";
 import NodePointProgram from "./rendering/webgl/programs/node.point";
 import EdgeRectangleProgram from "./rendering/webgl/programs/edge.rectangle";
-import EdgeArrowProgram from "./rendering/webgl/programs/edge.arrow";
+// import EdgeArrowProgram from "./rendering/webgl/programs/edge.arrow";
 import { EdgeProgramConstructor } from "./rendering/webgl/programs/common/edge";
 import { NodeProgramConstructor } from "./rendering/webgl/programs/common/node";
 
@@ -129,7 +129,7 @@ export const DEFAULT_NODE_PROGRAM_CLASSES = {
 };
 
 export const DEFAULT_EDGE_PROGRAM_CLASSES = {
-  arrow: EdgeArrowProgram,
+  // arrow: EdgeArrowProgram,
   line: EdgeRectangleProgram,
 };
 


### PR DESCRIPTION
@jacomyal this is not intended to be merged but more as a discussion item.

I repurposed the techniques I need to use in the curve program to offer an alternative way to render edges as rectangles.

I don't really know if this is faster (frankly I doubt it because the array is larger and the vertex shader computations are a tad more involved), but the shader code is way less magic/mystic as it is able to do its work by considering the viewport space we are rendering in. So no magic AA constants expressed in weird `0.001` units, no correction ratio or other ratio magic there, just "simple" geometry.

By the same logic it is also possible to do stuff such as nodes having a border expressed in pixels and not in a percentage, for instance.