### PR TITLE
Adding the #.setCamera method

### DIFF
--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -1260,6 +1260,18 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
   }
 
   /**
+   * Method setting the renderer's camera.
+   *
+   * @param  {Camera} camera - New camera.
+   * @return {Sigma}
+   */
+  setCamera(camera: Camera): void {
+    this.unbindCameraHandlers();
+    this.camera = camera;
+    this.bindCameraHandlers();
+  }
+
+  /**
    * Method returning the container DOM element.
    *
    * @return {HTMLElement}


### PR DESCRIPTION
@jacomyal this PR adds the `#.setCamera` method. A typical use-case is to make sure two sigma renderers share the same camera and have synchronized camera movements (like it is required for ipysigma's small multiples. I tried something lock-based but the way the Camera fires events, based on actual changes, makes this nontrivial and sharing a camera seems more obvious).

I did not add a `camera` setting but it might be useful to add here all the same? What do you think? The thing is that it might be awkard to deal with `#.setSetting` then in this configuration (the same could be said about the programs settings by the way).

Also I guess this method should schedule a render?