### PR TITLE
let nodes rescaling be configurable via settings

### DIFF
--- a/src/rendering/webgl/programs/common/program.ts
+++ b/src/rendering/webgl/programs/common/program.ts
@@ -14,6 +14,7 @@ export interface RenderParams {
   matrix: Float32Array;
   scalingRatio: number;
   correctionRatio: number;
+  nodesSizeZoomAdjuster: (ratio: number) => number;
 }
 
 export interface IProgram {

--- a/src/rendering/webgl/programs/node.fast.ts
+++ b/src/rendering/webgl/programs/node.fast.ts
@@ -51,7 +51,7 @@ export default class NodeFastProgram extends AbstractNodeProgram {
     const program = this.program;
     gl.useProgram(program);
 
-    gl.uniform1f(this.ratioLocation, 1 / Math.sqrt(params.ratio));
+    gl.uniform1f(this.ratioLocation, 1 / params.nodesSizeZoomAdjuster(params.ratio));
     gl.uniform1f(this.scaleLocation, params.scalingRatio);
     gl.uniformMatrix3fv(this.matrixLocation, false, params.matrix);
 

--- a/src/rendering/webgl/programs/node.image.ts
+++ b/src/rendering/webgl/programs/node.image.ts
@@ -241,7 +241,7 @@ export default function getNodeImageProgram(): typeof AbstractNodeImageProgram {
       const program = this.program;
       gl.useProgram(program);
 
-      gl.uniform1f(this.ratioLocation, 1 / Math.sqrt(params.ratio));
+      gl.uniform1f(this.ratioLocation, 1 / params.nodesSizeZoomAdjuster(params.ratio));
       gl.uniform1f(this.scaleLocation, params.scalingRatio);
       gl.uniformMatrix3fv(this.matrixLocation, false, params.matrix);
       gl.uniform1i(this.atlasLocation, 0);

--- a/src/rendering/webgl/programs/node.ts
+++ b/src/rendering/webgl/programs/node.ts
@@ -30,7 +30,7 @@ export default class NodeProgram extends AbstractProgram {
   angleLocation: GLint;
 
   matrixLocation: WebGLUniformLocation;
-  sqrtZoomRatioLocation: WebGLUniformLocation;
+  adjustedZoomRatioLocation: WebGLUniformLocation;
   correctionRatioLocation: WebGLUniformLocation;
 
   constructor(gl: WebGLRenderingContext) {
@@ -47,9 +47,9 @@ export default class NodeProgram extends AbstractProgram {
     if (matrixLocation === null) throw new Error("AbstractNodeProgram: error while getting matrixLocation");
     this.matrixLocation = matrixLocation;
 
-    const sqrtZoomRatioLocation = gl.getUniformLocation(this.program, "u_sqrtZoomRatio");
-    if (sqrtZoomRatioLocation === null) throw new Error("NodeProgram: error while getting sqrtZoomRatioLocation");
-    this.sqrtZoomRatioLocation = sqrtZoomRatioLocation;
+    const adjustedZoomRatioLocation = gl.getUniformLocation(this.program, "u_adjustedZoomRatio");
+    if (adjustedZoomRatioLocation === null) throw new Error("NodeProgram: error while getting adjustedZoomRatioLocation");
+    this.adjustedZoomRatioLocation = adjustedZoomRatioLocation;
 
     const correctionRatioLocation = gl.getUniformLocation(this.program, "u_correctionRatio");
     if (correctionRatioLocation === null) throw new Error("NodeProgram: error while getting correctionRatioLocation");
@@ -132,7 +132,7 @@ export default class NodeProgram extends AbstractProgram {
     gl.useProgram(program);
 
     gl.uniformMatrix3fv(this.matrixLocation, false, params.matrix);
-    gl.uniform1f(this.sqrtZoomRatioLocation, Math.sqrt(params.ratio));
+    gl.uniform1f(this.adjustedZoomRatioLocation, params.nodesSizeZoomAdjuster(params.ratio));
     gl.uniform1f(this.correctionRatioLocation, params.correctionRatio);
 
     gl.drawArrays(gl.TRIANGLES, 0, this.array.length / ATTRIBUTES);

--- a/src/rendering/webgl/shaders/node.vert.glsl
+++ b/src/rendering/webgl/shaders/node.vert.glsl
@@ -4,7 +4,7 @@ attribute float a_angle;
 attribute vec4 a_color;
 
 uniform mat3 u_matrix;
-uniform float u_sqrtZoomRatio;
+uniform float u_adjustedZoomRatio;
 uniform float u_correctionRatio;
 
 varying vec4 v_color;
@@ -16,7 +16,7 @@ const float bias = 255.0 / 254.0;
 const float marginRatio = 1.05;
 
 void main() {
-  float size = a_size * u_correctionRatio * u_sqrtZoomRatio * 4.0;
+  float size = a_size * u_correctionRatio * u_adjustedZoomRatio * 4.0;
   vec2 diffVector = size * vec2(cos(a_angle), sin(a_angle));
   vec2 position = a_position + diffVector * marginRatio;
   gl_Position = vec4(
@@ -25,7 +25,7 @@ void main() {
     1
   );
 
-  v_border = u_correctionRatio * u_sqrtZoomRatio * u_sqrtZoomRatio;
+  v_border = u_correctionRatio * u_adjustedZoomRatio * u_adjustedZoomRatio;
   v_diffVector = diffVector;
   v_radius = size / 2.0 / marginRatio;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -45,6 +45,7 @@ export interface Settings {
   edgeLabelWeight: string;
   edgeLabelColor: { attribute: string; color?: string } | { color: string; attribute?: undefined };
   stagePadding: number;
+  nodesSizeZoomAdjuster: (ratio: number) => number;
   // Labels
   labelDensity: number;
   labelGridCellSize: number;
@@ -93,6 +94,7 @@ export const DEFAULT_SETTINGS: Settings = {
   edgeLabelWeight: "normal",
   edgeLabelColor: { attribute: "color" },
   stagePadding: 30,
+  nodesSizeZoomAdjuster: Math.sqrt,
 
   // Labels
   labelDensity: 1,

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -1172,6 +1172,7 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
         ratio: this.camera.ratio,
         correctionRatio: this.correctionRatio / this.camera.ratio,
         scalingRatio: this.pixelRatio,
+        nodesSizeZoomAdjuster: this.settings.nodesSizeZoomAdjuster,
       });
     }
   }
@@ -1240,6 +1241,7 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
     const viewportDimensions = this.getDimensions();
     const graphDimensions = this.getGraphDimensions();
     const padding = this.getSetting("stagePadding") || 0;
+    const nodesSizeZoomAdjuster = this.getSetting("nodesSizeZoomAdjuster") || Math.sqrt;
     this.matrix = matrixFromCamera(cameraState, viewportDimensions, graphDimensions, padding);
     this.invMatrix = matrixFromCamera(cameraState, viewportDimensions, graphDimensions, padding, true);
     this.correctionRatio = getMatrixImpact(this.matrix, cameraState, viewportDimensions);
@@ -1257,6 +1259,7 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
         ratio: cameraState.ratio,
         correctionRatio: this.correctionRatio / cameraState.ratio,
         scalingRatio: this.pixelRatio,
+        nodesSizeZoomAdjuster: nodesSizeZoomAdjuster,
       });
     }
 
@@ -1274,6 +1277,7 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
           ratio: cameraState.ratio,
           correctionRatio: this.correctionRatio / cameraState.ratio,
           scalingRatio: this.pixelRatio,
+          nodesSizeZoomAdjuster: nodesSizeZoomAdjuster,
         });
       }
     }
@@ -1294,7 +1298,8 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
    */
   private updateCachedValues(): void {
     const { ratio } = this.camera.getState();
-    this.cameraSizeRatio = Math.sqrt(ratio);
+    const nodesSizeZoomAdjuster = this.getSetting("nodesSizeZoomAdjuster") || Math.sqrt;
+    this.cameraSizeRatio = nodesSizeZoomAdjuster(ratio);
   }
 
   /**---------------------------------------------------------------------------


### PR DESCRIPTION
as suggested by @jacomyal in #1185

the new nodesSizeZoomAdjuster setting expects a scaling function over ratio which is Math.sqrt by default

## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

> **_NOTE:_** Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?

> **_NOTE:_** Describe the behavior or changes that are being added by this PR.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.
