### PR TITLE
Allows sizes and positions in the same system

### DIFF
--- a/examples/fit-sizes-to-positions/index.html
+++ b/examples/fit-sizes-to-positions/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sigma example: Fit sizes to positions</title>
+  </head>
+  <body>
+    <style>
+      html,
+      body,
+      #sigma-container {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
+    </style>
+    <div id="sigma-container"></div>
+    <script src="build/bundle.js"></script>
+  </body>
+</html>

--- a/examples/fit-sizes-to-positions/index.ts
+++ b/examples/fit-sizes-to-positions/index.ts
@@ -1,0 +1,31 @@
+/**
+ * This is a minimal example of sigma. You can use it as a base to write new
+ * examples, or reproducible test cases for new issues, for instance.
+ */
+
+import Graph from "graphology";
+import Sigma from "sigma";
+import NodeCircleProgram from "../../src/rendering/webgl/programs/node.circle";
+
+const container = document.getElementById("sigma-container") as HTMLElement;
+
+const graph = new Graph();
+
+graph.addNode("Andrea", { x: 0, y: 0, size: 6, label: "Andrea", color: "blue" });
+graph.addNode("Bill", { x: 10, y: 0, size: 4, label: "Bill", color: "red" });
+graph.addNode("Carole", { x: 10, y: 10, size: 6, label: "Carole", color: "green" });
+graph.addNode("Daniel", { x: 0, y: 10, size: 4, label: "Daniel", color: "purple" });
+
+graph.addEdge("Andrea", "Bill", { size: 12 });
+graph.addEdge("Bill", "Carole", { size: 12 });
+graph.addEdge("Carole", "Daniel", { size: 8 });
+graph.addEdge("Daniel", "Andrea", { size: 8 });
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const renderer = new Sigma(graph, container, {
+  itemSizesReference: "positions",
+  zoomToSizeRatioFunction: (x) => x,
+  nodeProgramClasses: {
+    circle: NodeCircleProgram,
+  },
+});

--- a/examples/fit-sizes-to-positions/package.json
+++ b/examples/fit-sizes-to-positions/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "sigma-example-fit-sizes-to-positions",
+  "version": "1.0.0",
+  "description": "A minimalist sigma usage example.",
+  "main": "index.js",
+  "scripts": {
+    "start": "kotatsu serve --typescript index.ts --public / ./public"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "graphology": "^0.23.0",
+    "sigma": "latest"
+  },
+  "devDependencies": {
+    "kotatsu": "^0.22.3",
+    "typescript": "4.4.4"
+  }
+}

--- a/examples/fit-sizes-to-positions/sandbox.config.json
+++ b/examples/fit-sizes-to-positions/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "create-react-app"
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,6 +46,7 @@ export interface Settings {
   edgeLabelColor: { attribute: string; color?: string } | { color: string; attribute?: undefined };
   stagePadding: number;
   zoomToSizeRatioFunction: (ratio: number) => number;
+  itemSizesReference: "screen" | "positions";
   // Labels
   labelDensity: number;
   labelGridCellSize: number;
@@ -95,6 +96,7 @@ export const DEFAULT_SETTINGS: Settings = {
   edgeLabelColor: { attribute: "color" },
   stagePadding: 30,
   zoomToSizeRatioFunction: Math.sqrt,
+  itemSizesReference: "screen",
 
   // Labels
   labelDensity: 1,

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -181,7 +181,6 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
   });
 
   // Cache:
-  private cameraSizeRatio = 1;
   private graphToViewportRatio = 1;
 
   // Starting dimensions and pixel ratio


### PR DESCRIPTION
This ticket should solve #1185.

Details:
- Adds new setting "itemSizesReference", that can take either "screen" or "positions" as value (default is "screen")
- When the value is "screen", a node with a size of 10 will have a radius of 10px when the camera is not zoomed for instance
- When the value is "positions", node sizes are in the same system of their coordinates
- Adds new example `fit-sizes-to-positions` to illustrate this new feature