### PR TITLE
Adding the ability to control canvas order as an optional param

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,6 +47,7 @@ export interface Settings {
   stagePadding: number;
   zoomToSizeRatioFunction: (ratio: number) => number;
   itemSizesReference: "screen" | "positions";
+  canvasOrder: ("edges" | "nodes" | "edgeLabels" | "labels" | "hovers" | "hoverNodes" | "mouse")[];
   // Labels
   labelDensity: number;
   labelGridCellSize: number;
@@ -97,6 +98,7 @@ export const DEFAULT_SETTINGS: Settings = {
   stagePadding: 30,
   zoomToSizeRatioFunction: Math.sqrt,
   itemSizesReference: "screen",
+  canvasOrder: ["edges", "nodes", "edgeLabels", "labels", "hovers", "hoverNodes", "mouse"],
 
   // Labels
   labelDensity: 1,

--- a/src/sigma.ts
+++ b/src/sigma.ts
@@ -221,14 +221,24 @@ export default class Sigma<GraphType extends Graph = Graph> extends TypedEventEm
     this.graph = graph;
     this.container = container;
 
-    // Initializing contexts
-    this.createWebGLContext("edges", { preserveDrawingBuffer: true });
-    this.createCanvasContext("edgeLabels");
-    this.createWebGLContext("nodes");
-    this.createCanvasContext("labels");
-    this.createCanvasContext("hovers");
-    this.createWebGLContext("hoverNodes");
-    this.createCanvasContext("mouse");
+    // Initializing contexts (see settings.canvasOrder for details)
+    this.settings.canvasOrder.forEach((canvas: string) => {
+      switch (canvas) {
+        // edges is a special case
+        case "edges":
+          this.createWebGLContext("edges", { preserveDrawingBuffer: true });
+          break;
+        // Nodes and HoverNodes are also WebGLContexts
+        case "nodes":
+        case "hoverNodes":
+          this.createWebGLContext(canvas);
+          break;
+        // The rest are CanvasContexts
+        default:
+          this.createCanvasContext(canvas);
+          break;
+      }
+    });
 
     // Blending
     for (const key in this.webGLContexts) {


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

- Canvases are initiated in a set order, limiting the control the developer has over display (e.g. hover node is always over labels).

Issue Number: N/A

> **_NOTE:_** Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?

> **_NOTE:_** Describe the behavior or changes that are being added by this PR.

The default remains the same, but developers can now provide an optional canvasOrder array, which controls the order the canvases are layered, letting them put things where they want.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.
