### PR TITLE
Instanced rendering

### DIFF
--- a/examples/custom-rendering/node.border.ts
+++ b/examples/custom-rendering/node.border.ts
@@ -26,7 +26,6 @@ export default class NodeBorderProgram extends NodeProgram<typeof UNIFORMS[numbe
   getDefinition() {
     return {
       VERTICES: 1,
-      ARRAY_ITEMS_PER_VERTEX: 4,
       VERTEX_SHADER_SOURCE,
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,

--- a/src/rendering/webgl/programs/common/program.ts
+++ b/src/rendering/webgl/programs/common/program.ts
@@ -21,6 +21,15 @@ const SIZE_FACTOR_PER_ATTRIBUTE_TYPE: Record<number, number> = {
   [WebGL2RenderingContext.FLOAT]: 4,
 };
 
+function getAttributeItemsCount(attr: ProgramAttributeSpecification): number {
+  return attr.normalized ? 1 : attr.size;
+}
+function getAttributesItemsCount(attrs: ProgramAttributeSpecification[]): number {
+  let res = 0;
+  attrs.forEach((attr) => (res += getAttributeItemsCount(attr)));
+  return res;
+}
+
 export interface ProgramAttributeSpecification {
   name: string;
   size: number;
@@ -30,7 +39,6 @@ export interface ProgramAttributeSpecification {
 
 export interface ProgramDefinition<Uniform extends string = string> {
   VERTICES: number;
-  ARRAY_ITEMS_PER_VERTEX: number;
   VERTEX_SHADER_SOURCE: string;
   FRAGMENT_SHADER_SOURCE: string;
   UNIFORMS: ReadonlyArray<Uniform>;
@@ -77,11 +85,11 @@ export abstract class Program<Uniform extends string = string> implements Abstra
     const definition = this.getDefinition();
 
     this.VERTICES = definition.VERTICES;
-    this.ARRAY_ITEMS_PER_VERTEX = definition.ARRAY_ITEMS_PER_VERTEX;
     this.VERTEX_SHADER_SOURCE = definition.VERTEX_SHADER_SOURCE;
     this.FRAGMENT_SHADER_SOURCE = definition.FRAGMENT_SHADER_SOURCE;
     this.UNIFORMS = definition.UNIFORMS;
     this.ATTRIBUTES = definition.ATTRIBUTES;
+    this.ARRAY_ITEMS_PER_VERTEX = getAttributesItemsCount(this.ATTRIBUTES);
 
     // Computing stride
     this.STRIDE = this.VERTICES * this.ARRAY_ITEMS_PER_VERTEX;

--- a/src/rendering/webgl/programs/common/program.ts
+++ b/src/rendering/webgl/programs/common/program.ts
@@ -149,7 +149,7 @@ export abstract class Program<Uniform extends string = string> implements Abstra
             `Program: error while getting constant data (one vector has ${vector.length} items instead of ${constantAttributesItemsCount})`,
           );
 
-        constantData.push(...vector);
+        for (let j = 0; j < vector.length; j++) constantData.push(vector[j]);
       }
 
       this.STRIDE = this.ATTRIBUTES_ITEMS_COUNT;
@@ -224,12 +224,13 @@ export abstract class Program<Uniform extends string = string> implements Abstra
         gl.vertexAttribDivisor(location, 1);
       } else {
         const ext = gl.getExtension("ANGLE_instanced_arrays");
-        if (ext) ext.vertexAttribDivisorANGLE(location, 1);
+        if (!ext) throw new Error(`Program.bind: cannot retrieve WebGL extension "ANGLE_instanced_arrays"`);
+        ext.vertexAttribDivisorANGLE(location, 1);
       }
     }
 
     const sizeFactor = SIZE_FACTOR_PER_ATTRIBUTE_TYPE[attr.type];
-    if (typeof sizeFactor !== "number") throw new Error(`Program.bind: yet unsupported attribute type "${attr.type}"!`);
+    if (typeof sizeFactor !== "number") throw new Error(`Program.bind: yet unsupported attribute type "${attr.type}"`);
 
     return attr.size * sizeFactor;
   }

--- a/src/rendering/webgl/programs/edge.arrowHead.ts
+++ b/src/rendering/webgl/programs/edge.arrowHead.ts
@@ -19,7 +19,6 @@ export default class EdgeArrowHeadProgram extends EdgeProgram<typeof UNIFORMS[nu
   getDefinition() {
     return {
       VERTICES: 3,
-      ARRAY_ITEMS_PER_VERTEX: 9,
       VERTEX_SHADER_SOURCE,
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,

--- a/src/rendering/webgl/programs/edge.arrowHead.ts
+++ b/src/rendering/webgl/programs/edge.arrowHead.ts
@@ -27,7 +27,12 @@ export default class EdgeArrowHeadProgram extends EdgeProgram<typeof UNIFORMS[nu
         { name: "a_normal", size: 2, type: FLOAT },
         { name: "a_radius", size: 1, type: FLOAT },
         { name: "a_color", size: 4, type: UNSIGNED_BYTE, normalized: true },
-        { name: "a_barycentric", size: 3, type: FLOAT },
+      ],
+      CONSTANT_ATTRIBUTES: [{ name: "a_barycentric", size: 3, type: FLOAT }],
+      CONSTANT_DATA: [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
       ],
     };
   }
@@ -58,38 +63,12 @@ export default class EdgeArrowHeadProgram extends EdgeProgram<typeof UNIFORMS[nu
 
     const array = this.array;
 
-    // First point
     array[i++] = x2;
     array[i++] = y2;
     array[i++] = -n1;
     array[i++] = -n2;
     array[i++] = radius;
     array[i++] = color;
-    array[i++] = 1;
-    array[i++] = 0;
-    array[i++] = 0;
-
-    // Second point
-    array[i++] = x2;
-    array[i++] = y2;
-    array[i++] = -n1;
-    array[i++] = -n2;
-    array[i++] = radius;
-    array[i++] = color;
-    array[i++] = 0;
-    array[i++] = 1;
-    array[i++] = 0;
-
-    // Third point
-    array[i++] = x2;
-    array[i++] = y2;
-    array[i++] = -n1;
-    array[i++] = -n2;
-    array[i++] = radius;
-    array[i++] = color;
-    array[i++] = 0;
-    array[i++] = 0;
-    array[i] = 1;
   }
 
   draw(params: RenderParams): void {

--- a/src/rendering/webgl/programs/edge.arrowHead.ts
+++ b/src/rendering/webgl/programs/edge.arrowHead.ts
@@ -101,6 +101,6 @@ export default class EdgeArrowHeadProgram extends EdgeProgram<typeof UNIFORMS[nu
     gl.uniform1f(u_sizeRatio, params.sizeRatio);
     gl.uniform1f(u_correctionRatio, params.correctionRatio);
 
-    gl.drawArrays(gl.TRIANGLES, 0, this.verticesCount);
+    this.drawWebGL(gl.TRIANGLES);
   }
 }

--- a/src/rendering/webgl/programs/edge.clamped.ts
+++ b/src/rendering/webgl/programs/edge.clamped.ts
@@ -19,7 +19,6 @@ export default class EdgeClampedProgram extends EdgeRectangleProgram {
   getDefinition() {
     return {
       ...super.getDefinition(),
-      ARRAY_ITEMS_PER_VERTEX: 6,
       VERTEX_SHADER_SOURCE,
       ATTRIBUTES: [
         { name: "a_position", size: 2, type: FLOAT },

--- a/src/rendering/webgl/programs/edge.clamped.ts
+++ b/src/rendering/webgl/programs/edge.clamped.ts
@@ -21,10 +21,26 @@ export default class EdgeClampedProgram extends EdgeRectangleProgram {
       ...super.getDefinition(),
       VERTEX_SHADER_SOURCE,
       ATTRIBUTES: [
-        { name: "a_position", size: 2, type: FLOAT },
+        { name: "a_positionStart", size: 2, type: FLOAT },
+        { name: "a_positionEnd", size: 2, type: FLOAT },
         { name: "a_normal", size: 2, type: FLOAT },
         { name: "a_color", size: 4, type: UNSIGNED_BYTE, normalized: true },
         { name: "a_radius", size: 1, type: FLOAT },
+      ],
+      CONSTANT_ATTRIBUTES: [
+        // If 0, then position will be a_positionStart
+        // If 1, then position will be a_positionEnd
+        { name: "a_positionCoef", size: 1, type: FLOAT },
+        { name: "a_normalCoef", size: 1, type: FLOAT },
+        { name: "a_radiusCoef", size: 1, type: FLOAT },
+      ],
+      CONSTANT_DATA: [
+        [0, 1, 0],
+        [0, -1, 0],
+        [1, 1, 1],
+        [1, 1, 1],
+        [0, -1, 0],
+        [1, -1, -1],
       ],
     };
   }
@@ -56,36 +72,13 @@ export default class EdgeClampedProgram extends EdgeRectangleProgram {
 
     const array = this.array;
 
-    // First point
     array[i++] = x1;
     array[i++] = y1;
-    array[i++] = n1;
-    array[i++] = n2;
-    array[i++] = color;
-    array[i++] = 0;
-
-    // First point flipped
-    array[i++] = x1;
-    array[i++] = y1;
-    array[i++] = -n1;
-    array[i++] = -n2;
-    array[i++] = color;
-    array[i++] = 0;
-
-    // Second point
     array[i++] = x2;
     array[i++] = y2;
     array[i++] = n1;
     array[i++] = n2;
     array[i++] = color;
     array[i++] = radius;
-
-    // Second point flipped
-    array[i++] = x2;
-    array[i++] = y2;
-    array[i++] = -n1;
-    array[i++] = -n2;
-    array[i++] = color;
-    array[i] = -radius;
   }
 }

--- a/src/rendering/webgl/programs/edge.line.ts
+++ b/src/rendering/webgl/programs/edge.line.ts
@@ -20,7 +20,6 @@ export default class EdgeLineProgram extends EdgeProgram<typeof UNIFORMS[number]
   getDefinition() {
     return {
       VERTICES: 2,
-      ARRAY_ITEMS_PER_VERTEX: 3,
       VERTEX_SHADER_SOURCE,
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,

--- a/src/rendering/webgl/programs/edge.line.ts
+++ b/src/rendering/webgl/programs/edge.line.ts
@@ -57,6 +57,6 @@ export default class EdgeLineProgram extends EdgeProgram<typeof UNIFORMS[number]
 
     gl.uniformMatrix3fv(u_matrix, false, params.matrix);
 
-    gl.drawArrays(gl.LINES, 0, this.verticesCount);
+    this.drawWebGL(gl.LINES);
   }
 }

--- a/src/rendering/webgl/programs/edge.rectangle.ts
+++ b/src/rendering/webgl/programs/edge.rectangle.ts
@@ -28,14 +28,29 @@ const UNIFORMS = ["u_matrix", "u_zoomRatio", "u_sizeRatio", "u_correctionRatio"]
 export default class EdgeRectangleProgram extends EdgeProgram<typeof UNIFORMS[number]> {
   getDefinition() {
     return {
-      VERTICES: 4,
+      VERTICES: 6,
       VERTEX_SHADER_SOURCE,
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,
       ATTRIBUTES: [
-        { name: "a_position", size: 2, type: FLOAT },
+        { name: "a_positionStart", size: 2, type: FLOAT },
+        { name: "a_positionEnd", size: 2, type: FLOAT },
         { name: "a_normal", size: 2, type: FLOAT },
         { name: "a_color", size: 4, type: UNSIGNED_BYTE, normalized: true },
+      ],
+      CONSTANT_ATTRIBUTES: [
+        // If 0, then position will be a_positionStart
+        // If 2, then position will be a_positionEnd
+        { name: "a_positionCoef", size: 1, type: FLOAT },
+        { name: "a_normalCoef", size: 1, type: FLOAT },
+      ],
+      CONSTANT_DATA: [
+        [0, 1],
+        [0, -1],
+        [1, 1],
+        [1, 1],
+        [0, -1],
+        [1, -1],
       ],
     };
   }
@@ -65,47 +80,13 @@ export default class EdgeRectangleProgram extends EdgeProgram<typeof UNIFORMS[nu
 
     const array = this.array;
 
-    // First point
     array[i++] = x1;
     array[i++] = y1;
-    array[i++] = n1;
-    array[i++] = n2;
-    array[i++] = color;
-
-    // First point flipped
-    array[i++] = x1;
-    array[i++] = y1;
-    array[i++] = -n1;
-    array[i++] = -n2;
-    array[i++] = color;
-
-    // Second point
     array[i++] = x2;
     array[i++] = y2;
     array[i++] = n1;
     array[i++] = n2;
     array[i++] = color;
-
-    // Second point again
-    array[i++] = x2;
-    array[i++] = y2;
-    array[i++] = n1;
-    array[i++] = n2;
-    array[i++] = color;
-
-    // First point flipped again
-    array[i++] = x1;
-    array[i++] = y1;
-    array[i++] = -n1;
-    array[i++] = -n2;
-    array[i++] = color;
-
-    // Second point flipped
-    array[i++] = x2;
-    array[i++] = y2;
-    array[i++] = -n1;
-    array[i++] = -n2;
-    array[i] = color;
   }
 
   draw(params: RenderParams): void {

--- a/src/rendering/webgl/programs/edge.rectangle.ts
+++ b/src/rendering/webgl/programs/edge.rectangle.ts
@@ -29,7 +29,6 @@ export default class EdgeRectangleProgram extends EdgeProgram<typeof UNIFORMS[nu
   getDefinition() {
     return {
       VERTICES: 4,
-      ARRAY_ITEMS_PER_VERTEX: 5,
       VERTEX_SHADER_SOURCE,
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,

--- a/src/rendering/webgl/programs/edge.rectangle.ts
+++ b/src/rendering/webgl/programs/edge.rectangle.ts
@@ -118,6 +118,6 @@ export default class EdgeRectangleProgram extends EdgeProgram<typeof UNIFORMS[nu
     gl.uniform1f(u_sizeRatio, params.sizeRatio);
     gl.uniform1f(u_correctionRatio, params.correctionRatio);
 
-    gl.drawArrays(gl.TRIANGLES, 0, this.verticesCount);
+    this.drawWebGL(gl.TRIANGLES);
   }
 }

--- a/src/rendering/webgl/programs/edge.rectangle.ts
+++ b/src/rendering/webgl/programs/edge.rectangle.ts
@@ -40,23 +40,6 @@ export default class EdgeRectangleProgram extends EdgeProgram<typeof UNIFORMS[nu
     };
   }
 
-  reallocateIndices() {
-    const l = this.verticesCount;
-    const size = l + l / 2;
-    const indices = new this.IndicesArray(size);
-
-    for (let i = 0, c = 0; i < l; i += 4) {
-      indices[c++] = i;
-      indices[c++] = i + 1;
-      indices[c++] = i + 2;
-      indices[c++] = i + 2;
-      indices[c++] = i + 1;
-      indices[c++] = i + 3;
-    }
-
-    this.indicesArray = indices;
-  }
-
   processVisibleItem(i: number, sourceData: NodeDisplayData, targetData: NodeDisplayData, data: EdgeDisplayData) {
     const thickness = data.size || 1;
     const x1 = sourceData.x;
@@ -103,6 +86,20 @@ export default class EdgeRectangleProgram extends EdgeProgram<typeof UNIFORMS[nu
     array[i++] = n2;
     array[i++] = color;
 
+    // Second point again
+    array[i++] = x2;
+    array[i++] = y2;
+    array[i++] = n1;
+    array[i++] = n2;
+    array[i++] = color;
+
+    // First point flipped again
+    array[i++] = x1;
+    array[i++] = y1;
+    array[i++] = -n1;
+    array[i++] = -n2;
+    array[i++] = color;
+
     // Second point flipped
     array[i++] = x2;
     array[i++] = y2;
@@ -121,8 +118,6 @@ export default class EdgeRectangleProgram extends EdgeProgram<typeof UNIFORMS[nu
     gl.uniform1f(u_sizeRatio, params.sizeRatio);
     gl.uniform1f(u_correctionRatio, params.correctionRatio);
 
-    if (!this.indicesArray) throw new Error("EdgeRectangleProgram: indicesArray should be allocated when drawing!");
-
-    gl.drawElements(gl.TRIANGLES, this.indicesArray.length, this.indicesType, 0);
+    gl.drawArrays(gl.TRIANGLES, 0, this.verticesCount);
   }
 }

--- a/src/rendering/webgl/programs/edge.triangle.ts
+++ b/src/rendering/webgl/programs/edge.triangle.ts
@@ -84,6 +84,6 @@ export default class EdgeTriangleProgram extends EdgeProgram<typeof UNIFORMS[num
     gl.uniform1f(u_sizeRatio, params.sizeRatio);
     gl.uniform1f(u_correctionRatio, params.correctionRatio);
 
-    gl.drawArrays(gl.TRIANGLES, 0, this.verticesCount);
+    this.drawWebGL(gl.TRIANGLES);
   }
 }

--- a/src/rendering/webgl/programs/edge.triangle.ts
+++ b/src/rendering/webgl/programs/edge.triangle.ts
@@ -19,7 +19,6 @@ export default class EdgeTriangleProgram extends EdgeProgram<typeof UNIFORMS[num
   getDefinition() {
     return {
       VERTICES: 3,
-      ARRAY_ITEMS_PER_VERTEX: 5,
       VERTEX_SHADER_SOURCE,
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,

--- a/src/rendering/webgl/programs/edge.triangle.ts
+++ b/src/rendering/webgl/programs/edge.triangle.ts
@@ -23,9 +23,21 @@ export default class EdgeTriangleProgram extends EdgeProgram<typeof UNIFORMS[num
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,
       ATTRIBUTES: [
-        { name: "a_position", size: 2, type: FLOAT },
+        { name: "a_positionStart", size: 2, type: FLOAT },
+        { name: "a_positionEnd", size: 2, type: FLOAT },
         { name: "a_normal", size: 2, type: FLOAT },
         { name: "a_color", size: 4, type: UNSIGNED_BYTE, normalized: true },
+      ],
+      CONSTANT_ATTRIBUTES: [
+        // If 0, then position will be a_positionStart
+        // If 1, then position will be a_positionEnd
+        { name: "a_positionCoef", size: 1, type: FLOAT },
+        { name: "a_normalCoef", size: 1, type: FLOAT },
+      ],
+      CONSTANT_DATA: [
+        [0, 1],
+        [0, -1],
+        [1, 0],
       ],
     };
   }
@@ -58,21 +70,11 @@ export default class EdgeTriangleProgram extends EdgeProgram<typeof UNIFORMS[num
     // First point
     array[i++] = x1;
     array[i++] = y1;
+    array[i++] = x2;
+    array[i++] = y2;
     array[i++] = n1;
     array[i++] = n2;
     array[i++] = color;
-
-    array[i++] = x1;
-    array[i++] = y1;
-    array[i++] = -n1;
-    array[i++] = -n2;
-    array[i++] = color;
-
-    array[i++] = x2;
-    array[i++] = y2;
-    array[i++] = 0;
-    array[i++] = 0;
-    array[i] = color;
   }
 
   draw(params: RenderParams): void {

--- a/src/rendering/webgl/programs/node.circle.ts
+++ b/src/rendering/webgl/programs/node.circle.ts
@@ -26,7 +26,6 @@ export default class NodeCircleProgram extends NodeProgram<typeof UNIFORMS[numbe
   getDefinition() {
     return {
       VERTICES: 3,
-      ARRAY_ITEMS_PER_VERTEX: 5,
       VERTEX_SHADER_SOURCE,
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,

--- a/src/rendering/webgl/programs/node.circle.ts
+++ b/src/rendering/webgl/programs/node.circle.ts
@@ -35,7 +35,7 @@ export default class NodeCircleProgram extends NodeProgram<typeof UNIFORMS[numbe
         { name: "a_color", size: 4, type: UNSIGNED_BYTE, normalized: true },
       ],
       CONSTANT_ATTRIBUTES: [{ name: "a_angle", size: 1, type: FLOAT }],
-      CONSTANT_DATA: [NodeCircleProgram.ANGLE_1, NodeCircleProgram.ANGLE_2, NodeCircleProgram.ANGLE_3],
+      CONSTANT_DATA: [[NodeCircleProgram.ANGLE_1], [NodeCircleProgram.ANGLE_2], [NodeCircleProgram.ANGLE_3]],
     };
   }
 

--- a/src/rendering/webgl/programs/node.circle.ts
+++ b/src/rendering/webgl/programs/node.circle.ts
@@ -33,33 +33,20 @@ export default class NodeCircleProgram extends NodeProgram<typeof UNIFORMS[numbe
         { name: "a_position", size: 2, type: FLOAT },
         { name: "a_size", size: 1, type: FLOAT },
         { name: "a_color", size: 4, type: UNSIGNED_BYTE, normalized: true },
-        { name: "a_angle", size: 1, type: FLOAT },
       ],
+      CONSTANT_ATTRIBUTES: [{ name: "a_angle", size: 1, type: FLOAT }],
+      CONSTANT_DATA: [NodeCircleProgram.ANGLE_1, NodeCircleProgram.ANGLE_2, NodeCircleProgram.ANGLE_3],
     };
   }
 
   processVisibleItem(i: number, data: NodeDisplayData) {
     const array = this.array;
-
     const color = floatColor(data.color);
 
     array[i++] = data.x;
     array[i++] = data.y;
     array[i++] = data.size;
     array[i++] = color;
-    array[i++] = NodeCircleProgram.ANGLE_1;
-
-    array[i++] = data.x;
-    array[i++] = data.y;
-    array[i++] = data.size;
-    array[i++] = color;
-    array[i++] = NodeCircleProgram.ANGLE_2;
-
-    array[i++] = data.x;
-    array[i++] = data.y;
-    array[i++] = data.size;
-    array[i++] = color;
-    array[i] = NodeCircleProgram.ANGLE_3;
   }
 
   draw(params: RenderParams): void {
@@ -71,6 +58,6 @@ export default class NodeCircleProgram extends NodeProgram<typeof UNIFORMS[numbe
     gl.uniform1f(u_correctionRatio, params.correctionRatio);
     gl.uniformMatrix3fv(u_matrix, false, params.matrix);
 
-    gl.drawArrays(gl.TRIANGLES, 0, this.verticesCount);
+    this.drawWebGL(gl.TRIANGLES);
   }
 }

--- a/src/rendering/webgl/programs/node.image.ts
+++ b/src/rendering/webgl/programs/node.image.ts
@@ -283,7 +283,7 @@ export default function getNodeImageProgram(): NodeProgramConstructor {
       gl.uniformMatrix3fv(u_matrix, false, params.matrix);
       gl.uniform1i(u_atlas, 0);
 
-      gl.drawArrays(gl.POINTS, 0, this.verticesCount);
+      this.drawWebGL(gl.POINTS);
     }
   };
 }

--- a/src/rendering/webgl/programs/node.image.ts
+++ b/src/rendering/webgl/programs/node.image.ts
@@ -204,7 +204,6 @@ export default function getNodeImageProgram(): NodeProgramConstructor {
     getDefinition() {
       return {
         VERTICES: 1,
-        ARRAY_ITEMS_PER_VERTEX: 8,
         VERTEX_SHADER_SOURCE,
         FRAGMENT_SHADER_SOURCE,
         UNIFORMS,

--- a/src/rendering/webgl/programs/node.point.ts
+++ b/src/rendering/webgl/programs/node.point.ts
@@ -50,6 +50,6 @@ export default class NodePointProgram extends NodeProgram<typeof UNIFORMS[number
     gl.uniform1f(u_pixelRatio, params.pixelRatio);
     gl.uniformMatrix3fv(u_matrix, false, params.matrix);
 
-    gl.drawArrays(gl.POINTS, 0, this.verticesCount);
+    this.drawWebGL(gl.POINTS);
   }
 }

--- a/src/rendering/webgl/programs/node.point.ts
+++ b/src/rendering/webgl/programs/node.point.ts
@@ -21,7 +21,6 @@ export default class NodePointProgram extends NodeProgram<typeof UNIFORMS[number
   getDefinition() {
     return {
       VERTICES: 1,
-      ARRAY_ITEMS_PER_VERTEX: 4,
       VERTEX_SHADER_SOURCE,
       FRAGMENT_SHADER_SOURCE,
       UNIFORMS,

--- a/src/rendering/webgl/shaders/edge.clamped.vert.glsl
+++ b/src/rendering/webgl/shaders/edge.clamped.vert.glsl
@@ -1,7 +1,11 @@
 attribute vec4 a_color;
 attribute vec2 a_normal;
-attribute vec2 a_position;
+attribute float a_normalCoef;
+attribute vec2 a_positionStart;
+attribute vec2 a_positionEnd;
+attribute float a_positionCoef;
 attribute float a_radius;
+attribute float a_radiusCoef;
 
 uniform mat3 u_matrix;
 uniform float u_zoomRatio;
@@ -17,8 +21,12 @@ const float bias = 255.0 / 254.0;
 const float arrowHeadLengthThicknessRatio = 2.5;
 
 void main() {
-  float normalLength = length(a_normal);
-  vec2 unitNormal = a_normal / normalLength;
+  float radius = a_radius * a_radiusCoef;
+  vec2 normal = a_normal * a_normalCoef;
+  vec2 position = a_positionStart * (1.0 - a_positionCoef) + a_positionEnd * a_positionCoef;
+
+  float normalLength = length(normal);
+  vec2 unitNormal = normal / normalLength;
 
   // These first computations are taken from edge.vert.glsl. Please read it to
   // get better comments on what's happening:
@@ -26,14 +34,14 @@ void main() {
   float webGLThickness = pixelsThickness * u_correctionRatio / u_sizeRatio;
 
   // Here, we move the point to leave space for the arrow head:
-  float direction = sign(a_radius);
-  float webGLNodeRadius = direction * a_radius * 2.0 * u_correctionRatio / u_sizeRatio;
+  float direction = sign(radius);
+  float webGLNodeRadius = direction * radius * 2.0 * u_correctionRatio / u_sizeRatio;
   float webGLArrowHeadLength = webGLThickness * 2.0 * arrowHeadLengthThicknessRatio;
 
   vec2 compensationVector = vec2(-direction * unitNormal.y, direction * unitNormal.x) * (webGLNodeRadius + webGLArrowHeadLength);
 
   // Here is the proper position of the vertex
-  gl_Position = vec4((u_matrix * vec3(a_position + unitNormal * webGLThickness + compensationVector, 1)).xy, 0, 1);
+  gl_Position = vec4((u_matrix * vec3(position + unitNormal * webGLThickness + compensationVector, 1)).xy, 0, 1);
 
   v_thickness = webGLThickness / u_zoomRatio;
 

--- a/src/rendering/webgl/shaders/edge.rectangle.vert.glsl
+++ b/src/rendering/webgl/shaders/edge.rectangle.vert.glsl
@@ -1,6 +1,9 @@
 attribute vec4 a_color;
 attribute vec2 a_normal;
-attribute vec2 a_position;
+attribute float a_normalCoef;
+attribute vec2 a_positionStart;
+attribute vec2 a_positionEnd;
+attribute float a_positionCoef;
 
 uniform mat3 u_matrix;
 uniform float u_sizeRatio;
@@ -15,8 +18,11 @@ const float minThickness = 1.7;
 const float bias = 255.0 / 254.0;
 
 void main() {
-  float normalLength = length(a_normal);
-  vec2 unitNormal = a_normal / normalLength;
+  vec2 normal = a_normal * a_normalCoef;
+  vec2 position = a_positionStart * (1.0 - a_positionCoef) + a_positionEnd * a_positionCoef;
+
+  float normalLength = length(normal);
+  vec2 unitNormal = normal / normalLength;
 
   // We require edges to be at least `minThickness` pixels thick *on screen*
   // (so we need to compensate the size ratio):
@@ -28,7 +34,7 @@ void main() {
   float webGLThickness = pixelsThickness * u_correctionRatio / u_sizeRatio;
 
   // Here is the proper position of the vertex
-  gl_Position = vec4((u_matrix * vec3(a_position + unitNormal * webGLThickness, 1)).xy, 0, 1);
+  gl_Position = vec4((u_matrix * vec3(position + unitNormal * webGLThickness, 1)).xy, 0, 1);
 
   // For the fragment shader though, we need a thickness that takes the "magic"
   // correction ratio into account (as in webGLThickness), but so that the

--- a/src/rendering/webgl/shaders/edge.triangle.vert.glsl
+++ b/src/rendering/webgl/shaders/edge.triangle.vert.glsl
@@ -1,6 +1,9 @@
 attribute vec4 a_color;
 attribute vec2 a_normal;
-attribute vec2 a_position;
+attribute float a_normalCoef;
+attribute vec2 a_positionStart;
+attribute vec2 a_positionEnd;
+attribute float a_positionCoef;
 
 uniform mat3 u_matrix;
 uniform float u_sizeRatio;
@@ -12,16 +15,19 @@ const float minThickness = 1.7;
 const float bias = 255.0 / 254.0;
 
 void main() {
+  vec2 normal = a_normal * a_normalCoef;
+  vec2 position = a_positionStart * (1.0 - a_positionCoef) + a_positionEnd * a_positionCoef;
+
   // The only different here with edge.vert.glsl is that we need to handle null
   // input normal vector. Apart from that, you can read edge.vert.glsl more info
   // on how it works:
-  float normalLength = length(a_normal);
-  vec2 unitNormal = a_normal / normalLength;
-  if (normalLength <= 0.0) unitNormal = a_normal;
+  float normalLength = length(normal);
+  vec2 unitNormal = normal / normalLength;
+  if (normalLength <= 0.0) unitNormal = normal;
   float pixelsThickness = max(normalLength, minThickness * u_sizeRatio);
   float webGLThickness = pixelsThickness * u_correctionRatio / u_sizeRatio;
 
-  gl_Position = vec4((u_matrix * vec3(a_position + unitNormal * webGLThickness, 1)).xy, 0, 1);
+  gl_Position = vec4((u_matrix * vec3(position + unitNormal * webGLThickness, 1)).xy, 0, 1);
 
   v_color = a_color;
   v_color.a *= bias;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -431,15 +431,6 @@ export function extractPixel(gl: WebGLRenderingContext, x: number, y: number, ar
 }
 
 /**
- * Function used to know whether given webgl context can use 32 bits indices.
- */
-export function canUse32BitsIndices(gl: WebGLRenderingContext): boolean {
-  const webgl2 = typeof WebGL2RenderingContext !== "undefined" && gl instanceof WebGL2RenderingContext;
-
-  return webgl2 || !!gl.getExtension("OES_element_index_uint");
-}
-
-/**
  * Check if the graph variable is a valid graph, and if sigma can render it.
  */
 export function validateGraph(graph: Graph): void {


### PR DESCRIPTION
This PR implements **instanced rendering** for relevant programs. This should highly reduce RAM usage of sigma.js in most cases, and might increase performances as well. It fixes #1322.

**Details:**
- Removes `ARRAY_ITEMS_PER_VERTEX`, and automatically computes it instead
- Removes everything indices related from programs, since instanced rendering makes it useless
- Improves `common/program.ts` to handle instanced rendering:
  - Adds new `Program#drawWebGL(method: GLenum)` method, that handles calling the proper WebGL method, with the proper arguments
  - If the program's definition has `CONSTANT_DATA` and `CONSTANT_ATTRIBUTES`, it will be rendered using instanced rendering (works with both WebGL and WebGL2)
  - Also, programs now have an `#unbind` method that clears the related WebGL instance state before another program is used
- Ports every program that has multiple vertices to instanced rendering