### PR TITLE
Added crossOrigin option

### DIFF
--- a/src/rendering/webgl/programs/node.image.ts
+++ b/src/rendering/webgl/programs/node.image.ts
@@ -60,6 +60,8 @@ interface AbstractNodeImageProgramParams {
  * To share the texture between the program instances of the graph and the
  * hovered nodes (to prevent some flickering, mostly), this program must be
  * "built" for each sigma instance:
+ * 
+ * @param params Optional parameters for creating a node image program.
  */
 export default function getNodeImageProgram(params?: AbstractNodeImageProgramParams): typeof AbstractNodeImageProgram {
   /**

--- a/src/rendering/webgl/programs/node.image.ts
+++ b/src/rendering/webgl/programs/node.image.ts
@@ -42,11 +42,26 @@ class AbstractNodeImageProgram extends AbstractNodeProgram {
 }
 
 /**
+ * Optional parameters for creating a node image program.
+ */
+interface AbstractNodeImageProgramParams {
+  /**
+   * Custom "crossOrigin" attribute used to request the image.
+   * 
+   * By default, this is set to an empty string, implying "anonymous".
+   * Setting this to `null` will cause the image to be fetched without CORS.
+   * 
+   * See also https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin.
+   */
+  crossOrigin?: "" | "anonymous" | "use-credentials" | null;
+}
+
+/**
  * To share the texture between the program instances of the graph and the
  * hovered nodes (to prevent some flickering, mostly), this program must be
  * "built" for each sigma instance:
  */
-export default function getNodeImageProgram(): typeof AbstractNodeImageProgram {
+export default function getNodeImageProgram(params?: AbstractNodeImageProgramParams): typeof AbstractNodeImageProgram {
   /**
    * These attributes are shared between all instances of this exact class,
    * returned by this call to getNodeProgramImage:
@@ -62,6 +77,9 @@ export default function getNodeImageProgram(): typeof AbstractNodeImageProgram {
   let writePositionY = 0;
   // height of current row
   let writeRowHeight = 0;
+
+  // img crossOrigin setting
+  const crossOrigin = params?.crossOrigin === undefined ? "" : params.crossOrigin;
 
   interface PendingImage {
     image: HTMLImageElement;
@@ -92,7 +110,9 @@ export default function getNodeImageProgram(): typeof AbstractNodeImageProgram {
     images[imageSource] = { status: "loading" };
 
     // Load image:
-    image.setAttribute("crossOrigin", "");
+    if(crossOrigin !== null) {
+      image.setAttribute("crossOrigin", crossOrigin);
+    }
     image.src = imageSource;
   }
 


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

> **_NOTE:_** Describe the current behavior that you are modifying, or link to a relevant issue.

When using the node.image program, the `crossOrigin` attribute is hardcoded to `""` (anonymous fetch). If the img resource requires credentials, then image requests will always fail with HTTP 401, and the requested images will never be rendered on nodes.

## What is the new behavior?

> **_NOTE:_** Describe the behavior or changes that are being added by this PR.

Builds on PR #1147, where rather than hardcoding the `crossOrigin` attribute, the caller can provide a param value. Param value must be a valid HTML img crossOrigin value (TS check only). No breaking change in behavior - new `params` arg is optional. Also, FWIW, I've added a `null` param value which allows a user to override the behavior from PR #1147 and not specify a crossOrigin attribute.

This change specifically supports the (my) use case where node image URL resources are protected by a layer of authentication.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin