### PR TITLE
Fix broken documentation links

### DIFF
--- a/packages/website/docs/advanced/customization.md
+++ b/packages/website/docs/advanced/customization.md
@@ -30,7 +30,7 @@ Beyond these settings, sigma.js allows for more advanced customization of labels
 
 For most common cases (ie. straight edges and round nodes), you can directly override the `defaultDrawEdgeLabel`, `defaultDrawNodeLabel` and `defaultDrawNodeHover` settings. When you start having various shapes of nodes and/or edges (square nodes, curved edges...), you need to specify labels and hovered items renderers for each program. Each node program can have optional `drawLabel` and `drawHover` static methods, and each edge program can have an optional `drawLabel` static method.
 
-For a practical demonstration of this method, check out the website's demo, specifically the [`canvas-utils.ts` section](https://github.com/jacomyal/sigma.js/blob/main/demo/src/canvas-utils.ts).
+For a practical demonstration of this method, check out the website's demo, specifically the [`canvas-utils.ts` section](https://github.com/jacomyal/sigma.js/blob/main/packages/demo/src/canvas-utils.ts).
 
 ## Custom renderers
 

--- a/packages/website/docs/resources.md
+++ b/packages/website/docs/resources.md
@@ -13,4 +13,4 @@ Sigma.js offers a variety of resources to assist developers in understanding and
 
 3. **Source Code**: To delve deeper into the workings of sigma.js, the source code is a valuable resource. It is extensively commented, offering clarity on the library's operations and functionalities.
 
-4. **Demo Application**: For a real-world perspective, the sigma.js repository features a complete [demo](https://www.sigmajs.org/demo/index.html) ([sources](https://github.com/jacomyal/sigma.js/tree/main/demo)) built with [React](https://react.dev/). This demo mirrors the structure of a typical application, providing a practical view of how sigma.js can be integrated and used in a project context.
+4. **Demo Application**: For a real-world perspective, the sigma.js repository features a complete [demo](https://www.sigmajs.org/demo/index.html) ([sources](https://github.com/jacomyal/sigma.js/tree/main/packages/demo)) built with [React](https://react.dev/). This demo mirrors the structure of a typical application, providing a practical view of how sigma.js can be integrated and used in a project context.

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -65,7 +65,7 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/jacomyal/sigma.js/tree/main/packages/website/docs",
+          editUrl: "https://github.com/jacomyal/sigma.js/tree/main/packages/website",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),

--- a/packages/website/static/index.html
+++ b/packages/website/static/index.html
@@ -175,7 +175,7 @@
             <h2>Display</h2>
             <p>
               The most basic use case: you have a graph dataset, with colors, sizes and positions for each node. For
-              instance, you exported a <a href="https://gephi.org/gexf/format/">GEXF graph file</a> from
+              instance, you exported a <a href="https://gexf.net/">GEXF graph file</a> from
               <a href="https://gephi.org/">Gephi</a>. You want to visualize it using on a web page.
             </p>
             <p>

--- a/packages/website/static/index.html
+++ b/packages/website/static/index.html
@@ -107,7 +107,7 @@
         <div class="caption">
           <div class="links">
             <a href="./demo/index.html">open demo</a>
-            <a href="https://github.com/jacomyal/sigma.js/tree/main/demo">open demo sources</a>
+            <a href="https://github.com/jacomyal/sigma.js/tree/main/packages/demo">open demo sources</a>
           </div>
           <button class="button button-light restore-overlay-button" disabled>restore overlay over demo</button>
         </div>


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The following links are broken in [sigmajs.org](https://www.sigmajs.org/):

| Location | What is wrong? |
|---|---|
| `/` | The GEXF format documentation now has its own domain outside of gephi.org and the old URL renders a 404 page now. | 
| `/` | The `show demo source` label points to `sigma.js/tree/main/demo` instead of `sigma.js/tree/main/packages/demo`. |
| `/docs/resources/` | Same as above, the `show demo source` label points to outside of the `packages` folder. |
| `/docs/advanced/customization/` | The `canvas-utils.ts` link points to outside of the `packages` folder. |
| `/docs/<doc name>` | All `Edit this page` buttons from doc pages are not working because they point to `<...>/docs/docs/<doc name>`  instead of `<...>/docs/<doc name>`. It was supposed to be fixed by https://github.com/jacomyal/sigma.js/commit/c34233ba2442fe6ad2fb459822a0a883261e0b92 but it did not work. 😢  |

## What is the new behavior?

All links from above are now working. 😁  


