### PR TITLE
Fix GitHub link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This will open the Storybook in your web browser, which live reloads when you mo
 
 ## Resources
 
-- **GitHub Project:** The source code and collaborative development efforts for Sigma.js are hosted on [GitHub](https://github.com/sigma).
+- **GitHub Project:** The source code and collaborative development efforts for Sigma.js are hosted on [GitHub](https://github.com/jacomyal/sigma.js).
 - **Website:** The official website, [sigmajs.org](https://sigmajs.org), kindly designed by [Robin de Mourat](https://github.com/robindemourat/) from the [Sciences-Po médialab](https://medialab.sciencespo.fr/en/) team, showcases the library's capabilities.
 - **Documentation:** A detailed documentation, built with [Docusaurus](https://docusaurus.io/), is available at [sigmajs.org/docs](https://sigmajs.org/docs). It provides extensive guides and API references for users.
 - **Storybook:** Interactive examples can be found at [sigmajs.org/storybook](https://sigmajs.org/storybook).


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [ ] Other (please describe): Readme Change

## What is the current behavior?

The GitHub link in the readme links to an account unrelated to sigma.js.

## What is the new behavior?

This GitHub repo is linked.
