### PR TITLE
[@sigma/layer-leaflet] Adding leaflet map in graph background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5553,8 +5553,8 @@
       "resolved": "packages/edge-curve",
       "link": true
     },
-    "node_modules/@sigma/edge-self-loop": {
-      "resolved": "packages/edge-self-loop",
+    "node_modules/@sigma/layer-leaflet": {
+      "resolved": "packages/layer-leaflet",
       "link": true
     },
     "node_modules/@sigma/node-border": {
@@ -8638,6 +8638,12 @@
       "integrity": "sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==",
       "dev": true
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "dev": true
+    },
     "node_modules/@types/gtag.js": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
@@ -8709,6 +8715,15 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.12.tgz",
+      "integrity": "sha512-BK7XS+NyRI291HIo0HCfE18Lp8oA30H1gpi1tf0mF3TgiCEzanQjOqNZ4x126SXzzi2oNSZhZ5axJp1k0iM6jg==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/lodash": {
       "version": "4.17.0",
@@ -19183,6 +19198,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "peer": true
     },
     "node_modules/lerna": {
       "version": "8.1.2",
@@ -32607,8 +32628,37 @@
     "packages/edge-self-loop": {
       "name": "@sigma/edge-self-loop",
       "version": "3.0.0-beta.1",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
+        "sigma": ">=3.0.0-beta.10"
+      }
+    },
+    "packages/geographical-map": {
+      "name": "@sigma/geographical-map",
+      "version": "3.0.0-beta.13",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "maplibre-gl": "^4.5.0"
+      },
+      "devDependencies": {
+        "@types/leaflet": "^1.9.12"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.4",
+        "sigma": ">=3.0.0-beta.10"
+      }
+    },
+    "packages/layer-leaflet": {
+      "version": "3.0.0-beta.13",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/leaflet": "^1.9.12"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.4",
         "sigma": ">=3.0.0-beta.10"
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
       "packages/node-border",
       "packages/node-image",
       "packages/node-piechart",
-      "packages/edge-curve"
+      "packages/edge-curve",
+      "packages/layer-leaflet"
     ],
     "exports": {
       "importConditionDefaultExport": "default"

--- a/packages/layer-leaflet/.gitignore
+++ b/packages/layer-leaflet/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/layer-leaflet/.npmignore
+++ b/packages/layer-leaflet/.npmignore
@@ -1,0 +1,4 @@
+.gitignore
+node_modules
+src
+tsconfig.json

--- a/packages/layer-leaflet/README.md
+++ b/packages/layer-leaflet/README.md
@@ -1,0 +1,26 @@
+# Sigma.js Leaflet background layer
+
+This package contains a leaflet backgournd layer for [sigma.js](https://sigmajs.org).
+
+It displays a map on the graph's background and handle the camera synchronisation. 
+
+## How to use
+
+First you need to install [leaflet](https://leafletjs.com/) in your application.
+You can check this [page](https://leafletjs.com/download.html) to see how to do it. 
+
+Then, within your application that uses sigma.js, you can use [`@sigma/layer-leaflet`](https://www.npmjs.com/package/@sigma/layer-leaflet) as following:
+
+```typescript
+import bindLeafletLayer from "@sigma/layer-leaflet";
+
+const graph = new Graph();
+graph.addNode("nantes", { x: 0, y: 0, lat:47.2308, lng:1.5566, size: 10, label: "nantes" });
+graph.addNode("paris", {  x: 0, y: 0, lat: 48.8567, lng:2.3510, size: 10, label: "Paris" });
+graph.addEdge("nantes", "paris");
+
+const sigma = new Sigma(graph, container);
+bindLeafletLayer(sigma);
+```
+
+Please check the related [Storybook](https://github.com/jacomyal/sigma.js/tree/main/packages/storybook/stories/layer-leaflet) for more advanced examples.

--- a/packages/layer-leaflet/package.json
+++ b/packages/layer-leaflet/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@sigma/layer-leaflet",
+  "version": "3.0.0-beta.13",
+  "description": "A plugin to set a geographical map in background",
+  "main": "dist/sigma-layer-leaflet.cjs.js",
+  "module": "dist/sigma-layer-leaflet.esm.js",
+  "types": "dist/sigma-layer-leaflet.cjs.d.ts",
+  "files": [
+    "/dist"
+  ],
+  "sideEffects": false,
+  "homepage": "https://www.sigmajs.org",
+  "bugs": "http://github.com/jacomyal/sigma.js/issues",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/jacomyal/sigma.js.git"
+  },
+  "keywords": [
+    "graph",
+    "graphology",
+    "sigma"
+  ],
+  "license": "MIT",
+  "preconstruct": {
+    "entrypoints": [
+      "index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "leaflet": "^1.9.4",
+    "sigma": ">=3.0.0-beta.10"
+  },
+  "exports": {
+    ".": {
+      "module": "./dist/sigma-layer-leaflet.esm.js",
+      "import": "./dist/sigma-layer-leaflet.cjs.mjs",
+      "default": "./dist/sigma-layer-leaflet.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "devDependencies": {
+    "@types/leaflet": "^1.9.12"
+  }
+}

--- a/packages/layer-leaflet/src/index.ts
+++ b/packages/layer-leaflet/src/index.ts
@@ -1,0 +1,112 @@
+import Graph from "graphology";
+import { Attributes } from "graphology-types";
+import L from "leaflet";
+import { Sigma } from "sigma";
+import { DEFAULT_SETTINGS } from "sigma/settings";
+
+import { graphToLatlng, latlngToGraph, setSigmaRatioBounds, syncLeafletBboxWithGraph } from "./utils";
+
+/**
+ * On the graph, we store the 2D projection of the geographical lat/long.
+ */
+export default function bindLeafletLayer(
+  sigma: Sigma,
+  opts?: {
+    tileLayer?: { urlTemplate: string; attribution?: string };
+    getNodeLatLng?: (nodeAttributes: Attributes) => { lat: number; lng: number };
+  },
+) {
+  // Creating map container for leaflet
+  const mapContainer = document.createElement("div");
+  const mapContainerId = `${sigma.getContainer().id}-map`;
+  mapContainer.setAttribute("id", mapContainerId);
+  mapContainer.setAttribute("style", "position: relative; top:0; left:0; width: 100%; height:100%; z-index:-1");
+  sigma.getContainer().appendChild(mapContainer);
+
+  // Initialize the map
+  const map = L.map(mapContainerId, {
+    zoomControl: false,
+    zoomSnap: 0,
+    zoom: 0,
+    // we force the maxZoom with a higher tile value so leaflet function are not stucks
+    // in a restricted area. It avoids side effect
+    maxZoom: 20,
+  }).setView([0, 0], 0);
+  let tileUrl = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
+  let tileAttribution: string | undefined =
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+  if (opts?.tileLayer) {
+    tileUrl = opts.tileLayer.urlTemplate;
+    tileAttribution = opts.tileLayer.attribution;
+  }
+  L.tileLayer(tileUrl, { attribution: tileAttribution }).addTo(map);
+
+  // `stagePadding: 0` is mandatory, so the bbox of the map & Sigma is the same.
+  sigma.setSetting("stagePadding", 0);
+
+  // Function that change the given graph by generating the sigma x,y coords by taking the geo coordinates
+  // and project them in the 2D space of the map
+  function updateGraphCoordinates(graph: Graph) {
+    graph.updateEachNodeAttributes((_node, attrs) => {
+      const coords = latlngToGraph(
+        map,
+        opts?.getNodeLatLng ? opts.getNodeLatLng(attrs) : { lat: attrs.lat, lng: attrs.lng },
+      );
+      return {
+        ...attrs,
+        x: coords.x,
+        y: coords.y,
+      };
+    });
+  }
+
+  // Function that do sync sigma->leaflet
+  function fnSyncLeaflet(animate = false) {
+    syncLeafletBboxWithGraph(sigma, map, animate);
+  }
+
+  // When sigma is resize, we need to update the graph coordinate (the ref has changed)
+  // and recompute the zoom bounds
+  function fnOnResize() {
+    updateGraphCoordinates(sigma.getGraph());
+    setSigmaRatioBounds(sigma, map);
+  }
+
+  // Clean up function to remove everything
+  function clean() {
+    map.remove();
+    mapContainer.remove();
+    sigma.off("afterRender", fnSyncLeaflet);
+    sigma.off("resize", fnOnResize);
+    sigma.setSetting("stagePadding", DEFAULT_SETTINGS.stagePadding);
+  }
+
+  // WHen the map is ready
+  map.whenReady(() => {
+    // Update the sigma graph for geopspatial coords
+    updateGraphCoordinates(sigma.getGraph());
+
+    // Do the first sync
+    fnSyncLeaflet();
+
+    // Compute sigma ratio bounds
+    map.once("moveend", () => {
+      setSigmaRatioBounds(sigma, map);
+    });
+
+    // At each render of sigma, we do the leaflet sync
+    sigma.on("afterRender", fnSyncLeaflet);
+    // Listen on resize
+    sigma.on("resize", fnOnResize);
+    // Do the cleanup
+    sigma.on("kill", clean);
+  });
+
+  return {
+    clean,
+    map,
+    updateGraphCoordinates,
+  };
+}
+
+export { graphToLatlng, latlngToGraph };

--- a/packages/layer-leaflet/src/utils.ts
+++ b/packages/layer-leaflet/src/utils.ts
@@ -1,0 +1,77 @@
+import { LatLngBounds, Map } from "leaflet";
+import { Sigma } from "sigma";
+
+export const LEAFLET_MAX_PIXEL = 256 * 2 ** 18;
+
+/**
+ * Given a geo point returns its graph coords.
+ */
+export function latlngToGraph(map: Map, coord: { lat: number; lng: number }): { x: number; y: number } {
+  const data = map.project({ lat: coord.lat, lng: coord.lng }, 0);
+  return {
+    x: data.x,
+    // Y are reversed between geo / sigma
+    y: map.getContainer().clientHeight - data.y,
+  };
+}
+
+/**
+ * Given a graph coords returns it's lat/lng coords.
+ */
+export function graphToLatlng(map: Map, coords: { x: number; y: number }): { lat: number; lng: number } {
+  const data = map.unproject([coords.x, map.getContainer().clientHeight - coords.y], 0);
+  return { lat: data.lat, lng: data.lng };
+}
+
+/**
+ * Synchronise the sigma BBOX with the leaflet one.
+ */
+export function syncLeafletBboxWithGraph(sigma: Sigma, map: Map, animate: boolean): void {
+  const viewportDimensions = sigma.getDimensions();
+
+  // Graph BBOX
+  const graphBottomLeft = sigma.viewportToGraph({ x: 0, y: viewportDimensions.height }, { padding: 0 });
+  const graphTopRight = sigma.viewportToGraph({ x: viewportDimensions.width, y: 0 }, { padding: 0 });
+
+  // Geo BBOX
+  const geoSouthWest = graphToLatlng(map, graphBottomLeft);
+  const geoNorthEast = graphToLatlng(map, graphTopRight);
+
+  // Set map BBOX
+  const bounds = new LatLngBounds(geoSouthWest, geoNorthEast);
+  const opts = animate ? { animate: true, duration: 0.001 } : { animate: false };
+  map.flyToBounds(bounds, opts);
+
+  // Handle side effects when bounds have some "void" area on top or bottom of the map
+  // When it happens, flyToBound don't really do its job and there is a translation of the graph that match the void height.
+  // So we have to do a pan in pixel...
+  const worldSize = map.getPixelWorldBounds().getSize();
+  const mapBottomY = map.getPixelBounds().getBottomLeft().y;
+  const mapTopY = map.getPixelBounds().getTopRight().y;
+  const panVector: [number, number] = [0, 0];
+  if (mapTopY < 0) panVector[1] = mapTopY;
+  if (mapBottomY > worldSize.y) panVector[1] = mapBottomY - worldSize.y + panVector[1];
+  if (panVector[1] !== 0) {
+    map.panBy(panVector, { animate: false });
+  }
+}
+
+/**
+ * Settings the min & max camera ratio of sigma to not be hover the possibility of leaflet
+ * - Max zoom is when whe can see the whole map
+ * - Min zoom is when we are at zoom 18 on leaflet
+ */
+export function setSigmaRatioBounds(sigma: Sigma, map: Map): void {
+  const worldPixelSize = map.getPixelWorldBounds().getSize();
+
+  // Max zoom
+  const maxZoomRatio = worldPixelSize.y / sigma.getDimensions().width;
+  sigma.setSetting("maxCameraRatio", maxZoomRatio);
+  // Min zoom
+  const minZoomRatio = worldPixelSize.y / LEAFLET_MAX_PIXEL;
+  sigma.setSetting("minCameraRatio", minZoomRatio);
+
+  const currentRatio = sigma.getCamera().ratio;
+  if (currentRatio > maxZoomRatio) sigma.getCamera().setState({ ratio: maxZoomRatio });
+  if (currentRatio < minZoomRatio) sigma.getCamera().setState({ ratio: minZoomRatio });
+}

--- a/packages/layer-leaflet/tsconfig.json
+++ b/packages/layer-leaflet/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ESNext", // Specifies the JavaScript version to target when transpiling code.
+    "useDefineForClassFields": true, // Enables the use of 'define' for class fields.
+    "lib": ["ES2020", "DOM", "DOM.Iterable"], // Specifies the libraries available for the code.
+    "module": "ESNext", // Defines the module system to use for code generation.
+    "skipLibCheck": true, // Skips type checking of declaration files.
+
+    /* Bundler mode */
+    "moduleResolution": "node", // Specifies how modules are resolved when bundling.
+    "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true, // Allows importing TypeScript files with extensions.
+    "resolveJsonModule": true, // Enables importing JSON modules.
+    "isolatedModules": true, // Ensures each file is treated as a separate module.
+    "noEmit": true, // Prevents TypeScript from emitting output files.
+
+    /* Linting */
+    "strict": true, // Enables strict type checking.
+    "noUnusedLocals": true, // Flags unused local variables.
+    "noUnusedParameters": true, // Flags unused function parameters.
+    "noFallthroughCasesInSwitch": true, // Requires handling all cases in a switch statement.
+    "declaration": true // Generates declaration files for TypeScript.
+  },
+  "include": ["src"], // Specifies the directory to include when searching for TypeScript files.
+  "exclude": ["src/**/__docs__", "src/**/__test__"]
+}

--- a/packages/storybook/stories/layer-leaflet/basic.ts
+++ b/packages/storybook/stories/layer-leaflet/basic.ts
@@ -1,0 +1,42 @@
+/**
+ * This is a minimal example of sigma. You can use it as a base to write new
+ * examples, or reproducible test cases for new issues, for instance.
+ */
+import bindLeafletLayer from "@sigma/layer-leaflet";
+import Graph from "graphology";
+import { Attributes, SerializedGraph } from "graphology-types";
+import Sigma from "sigma";
+
+import { onStoryDown } from "../utils";
+import data from "./data/airports.json";
+
+export default () => {
+  const container = document.getElementById("sigma-container") as HTMLElement;
+  const graph = Graph.from(data as SerializedGraph);
+  graph.updateEachNodeAttributes((_node, attributes) => ({
+    ...attributes,
+    x: 0,
+    y: 0,
+  }));
+
+  // initiate sigma
+  const renderer = new Sigma(graph, container, {
+    labelRenderedSizeThreshold: 20,
+    nodeReducer: (node, attrs) => {
+      return {
+        ...attrs,
+        label: attrs.fullName,
+        color: "#e22352",
+        size: Math.sqrt(graph.degree(node)) / 2,
+      };
+    },
+  });
+
+  onStoryDown(() => {
+    renderer.kill();
+  });
+
+  bindLeafletLayer(renderer, {
+    getNodeLatLng: (attrs: Attributes) => ({ lat: attrs.latitude, lng: attrs.longitude }),
+  });
+};

--- a/packages/storybook/stories/layer-leaflet/data/sample-geojson.json
+++ b/packages/storybook/stories/layer-leaflet/data/sample-geojson.json
@@ -1,0 +1,68 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -105.00341892242432,
+            39.75383843460583
+          ],
+          [
+            -105.0008225440979,
+            39.751891803969535
+          ]
+        ]
+      },
+      "properties": {
+        "popupContent": "This is a free bus line that will take you across downtown.",
+        "underConstruction": false
+      },
+      "id": 1
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -105.0008225440979,
+            39.751891803969535
+          ],
+          [
+            -104.99820470809937,
+            39.74979664004068
+          ]
+        ]
+      },
+      "properties": {
+        "popupContent": "This is a free bus line that will take you across downtown.",
+        "underConstruction": true
+      },
+      "id": 2
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -104.99820470809937,
+            39.74979664004068
+          ],
+          [
+            -104.98689651489258,
+            39.741052354709055
+          ]
+        ]
+      },
+      "properties": {
+        "popupContent": "This is a free bus line that will take you across downtown.",
+        "underConstruction": false
+      },
+      "id": 3
+    }
+  ]
+}

--- a/packages/storybook/stories/layer-leaflet/geojson.ts
+++ b/packages/storybook/stories/layer-leaflet/geojson.ts
@@ -1,0 +1,42 @@
+/**
+ * This is a minimal example of sigma. You can use it as a base to write new
+ * examples, or reproducible test cases for new issues, for instance.
+ */
+import bindLeafletLayer, { graphToLatlng } from "@sigma/layer-leaflet";
+import { FeatureCollection } from "geojson";
+import Graph from "graphology";
+import L from "leaflet";
+import Sigma from "sigma";
+
+import { onStoryDown } from "../utils";
+import geojson from "./data/sample-geojson.json";
+
+export default () => {
+  const container = document.getElementById("sigma-container") as HTMLElement;
+  const graph = new Graph();
+  graph.addNode("b-cycle-51", { x: 0, y: 0, lat: 39.7471494, lng: -104.9998241, size: 20, color: "#e22352" });
+  graph.addNode("b-cycle-52", { x: 0, y: 0, lat: 39.7502833, lng: -104.9983545, size: 20, color: "#e22352" });
+  graph.addEdge("b-cycle-51", "b-cycle-52");
+
+  // Initiate sigma
+  const renderer = new Sigma(graph, container);
+  const { map } = bindLeafletLayer(renderer);
+
+  // Add a geojson on the map
+  L.geoJSON(geojson as FeatureCollection).addTo(map);
+
+  // When clicking on the stage of sigma,
+  // create a marker on the map
+  let markerOnClick: null | L.Marker = null;
+  renderer.on("clickStage", (e) => {
+    const graphCoords = renderer.viewportToGraph({ x: e.event.x, y: e.event.y });
+    const geoCoords = graphToLatlng(map, graphCoords);
+    if (markerOnClick) markerOnClick.remove();
+    markerOnClick = L.marker(geoCoords);
+    markerOnClick.addTo(map);
+  });
+
+  onStoryDown(() => {
+    renderer.kill();
+  });
+};

--- a/packages/storybook/stories/layer-leaflet/index.html
+++ b/packages/storybook/stories/layer-leaflet/index.html
@@ -1,0 +1,19 @@
+<style>
+  html,
+  body,
+  #storybook-root,
+  #sigma-container {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      z-index: 500;
+  }
+</style>
+<div id="sigma-container"></div>
+<link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+  />
+  

--- a/packages/storybook/stories/layer-leaflet/stories.ts
+++ b/packages/storybook/stories/layer-leaflet/stories.ts
@@ -1,0 +1,50 @@
+import { Meta, StoryObj } from "@storybook/html";
+
+import basicPlay from "./basic";
+import basicSource from "./basic?raw";
+import geojsonPlay from "./geojson";
+import geojsonSource from "./geojson?raw";
+import template from "./index.html?raw";
+import tilelayerPlay from "./tilelayer";
+import tilelayerSource from "./tilelayer?raw";
+
+const meta: Meta = {
+  id: "layer-leaflet",
+  title: "layer-leaflet",
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const story: Story = {
+  name: "Basic example",
+  render: () => template,
+  play: basicPlay,
+  parameters: {
+    storySource: {
+      source: basicSource,
+    },
+  },
+};
+
+export const otherTileLayer: Story = {
+  name: "Other tile layer",
+  render: () => template,
+  play: tilelayerPlay,
+  parameters: {
+    storySource: {
+      source: tilelayerSource,
+    },
+  },
+};
+
+export const withAGeoJson: Story = {
+  name: "Map interactions",
+  render: () => template,
+  play: geojsonPlay,
+  parameters: {
+    storySource: {
+      source: geojsonSource,
+    },
+  },
+};

--- a/packages/storybook/stories/layer-leaflet/tilelayer.ts
+++ b/packages/storybook/stories/layer-leaflet/tilelayer.ts
@@ -1,0 +1,43 @@
+import bindLeafletLayer from "@sigma/layer-leaflet";
+import Graph from "graphology";
+import { Attributes, SerializedGraph } from "graphology-types";
+import Sigma from "sigma";
+
+import { onStoryDown } from "../utils";
+import data from "./data/airports.json";
+
+export default () => {
+  const container = document.getElementById("sigma-container") as HTMLElement;
+  const graph = Graph.from(data as SerializedGraph);
+  graph.updateEachNodeAttributes((_node, attributes) => ({
+    ...attributes,
+    x: 0,
+    y: 0,
+  }));
+
+  // initiate sigma
+  const renderer = new Sigma(graph, container, {
+    labelRenderedSizeThreshold: 20,
+    nodeReducer: (node, attrs) => {
+      return {
+        ...attrs,
+        label: attrs.fullName,
+        color: "#e22352",
+        size: Math.sqrt(graph.degree(node)),
+      };
+    },
+  });
+
+  onStoryDown(() => {
+    renderer.kill();
+  });
+
+  bindLeafletLayer(renderer, {
+    tileLayer: {
+      urlTemplate: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+    },
+    getNodeLatLng: (attrs: Attributes) => ({ lat: attrs.latitude, lng: attrs.longitude }),
+  });
+};


### PR DESCRIPTION
 Adding leaflet map in graph background

* Update the sigma's graph with the projected lat/lng coordinates
* Sync the sigma & leaflet view box
* Add limits on sigma zoom ratio to not be outside the leaflet capabilities

What can be enhance : 
- adding animation on `flyToBound` to have smooth transition. But it's not so simple. I'm assuming there is some bounds attraction at the end of the animation. Moreover, it's not easy to know when the animation has finished. This is needed in some cases (like the recomputation of ratio bounds on a resize).
- be able to center the map/graph on a longitude (and if we can do that, it can be cool to test it when panning)
