### PR TITLE
Be able to disable camera rotation

### DIFF
--- a/packages/layer-leaflet/src/index.ts
+++ b/packages/layer-leaflet/src/index.ts
@@ -44,6 +44,9 @@ export default function bindLeafletLayer(
   // `stagePadding: 0` is mandatory, so the bbox of the map & Sigma is the same.
   sigma.setSetting("stagePadding", 0);
 
+  // disable camera rotation (leaflet doesn't handle it)
+  sigma.setSetting("enableCameraRotation", false);
+
   // Function that change the given graph by generating the sigma x,y coords by taking the geo coordinates
   // and project them in the 2D space of the map
   function updateGraphCoordinates(graph: Graph) {
@@ -79,9 +82,10 @@ export default function bindLeafletLayer(
     sigma.off("afterRender", fnSyncLeaflet);
     sigma.off("resize", fnOnResize);
     sigma.setSetting("stagePadding", DEFAULT_SETTINGS.stagePadding);
+    sigma.setSetting("enableCameraRotation", true);
   }
 
-  // WHen the map is ready
+  // When the map is ready
   map.whenReady(() => {
     // Update the sigma graph for geospatial coords
     updateGraphCoordinates(sigma.getGraph());

--- a/packages/sigma/src/core/camera.ts
+++ b/packages/sigma/src/core/camera.ts
@@ -33,6 +33,7 @@ export default class Camera extends TypedEventEmitter<CameraEvents> implements C
 
   minRatio: number | null = null;
   maxRatio: number | null = null;
+  enabledRotation = true;
 
   private nextFrame: number | null = null;
   private previousState: CameraState | null = null;
@@ -142,7 +143,7 @@ export default class Camera extends TypedEventEmitter<CameraEvents> implements C
     const validatedState: Partial<CameraState> = {};
     if (typeof state.x === "number") validatedState.x = state.x;
     if (typeof state.y === "number") validatedState.y = state.y;
-    if (typeof state.angle === "number") validatedState.angle = state.angle;
+    if (this.enabledRotation && typeof state.angle === "number") validatedState.angle = state.angle;
     if (typeof state.ratio === "number") validatedState.ratio = this.getBoundedRatio(state.ratio);
     return validatedState;
   }
@@ -173,7 +174,7 @@ export default class Camera extends TypedEventEmitter<CameraEvents> implements C
     const validState = this.validateState(state);
     if (typeof validState.x === "number") this.x = validState.x;
     if (typeof validState.y === "number") this.y = validState.y;
-    if (typeof validState.angle === "number") this.angle = validState.angle;
+    if (this.enabledRotation && typeof validState.angle === "number") this.angle = validState.angle;
     if (typeof validState.ratio === "number") this.ratio = validState.ratio;
 
     // Emitting
@@ -239,7 +240,7 @@ export default class Camera extends TypedEventEmitter<CameraEvents> implements C
 
       if (typeof validState.x === "number") newState.x = initialState.x + (validState.x - initialState.x) * coefficient;
       if (typeof validState.y === "number") newState.y = initialState.y + (validState.y - initialState.y) * coefficient;
-      if (typeof validState.angle === "number")
+      if (this.enabledRotation && typeof validState.angle === "number")
         newState.angle = initialState.angle + (validState.angle - initialState.angle) * coefficient;
       if (typeof validState.ratio === "number")
         newState.ratio = initialState.ratio + (validState.ratio - initialState.ratio) * coefficient;

--- a/packages/sigma/src/settings.ts
+++ b/packages/sigma/src/settings.ts
@@ -73,6 +73,7 @@ export interface Settings<
   zIndex: boolean;
   minCameraRatio: null | number;
   maxCameraRatio: null | number;
+  enableCameraRotation: boolean;
 
   // Lifecycle
   allowInvalidContainer: boolean;
@@ -126,6 +127,7 @@ export const DEFAULT_SETTINGS: Settings<Attributes, Attributes, Attributes> = {
   zIndex: false,
   minCameraRatio: null,
   maxCameraRatio: null,
+  enableCameraRotation: true,
 
   // Lifecycle
   allowInvalidContainer: false,

--- a/packages/sigma/src/sigma.ts
+++ b/packages/sigma/src/sigma.ts
@@ -839,6 +839,7 @@ export default class Sigma<
 
     this.camera.minRatio = settings.minCameraRatio;
     this.camera.maxRatio = settings.maxCameraRatio;
+    this.camera.enabledRotation = settings.enableCameraRotation;
     this.camera.setState(this.camera.validateState(this.camera.getState()));
 
     if (oldSettings) {


### PR DESCRIPTION
- adding `enableCameraRotation` setting in sigma (default to true)
- If disabled, `angle` is ignored in camera
- Disable camera rotation in @sigma/layer-leaflet
