### PR TITLE
[edge-curve] Change label orientation to make them easier to read

### DIFF
--- a/packages/edge-curve/src/edge-labels.ts
+++ b/packages/edge-curve/src/edge-labels.ts
@@ -50,10 +50,11 @@ export function createDrawCurvedEdgeLabel<
     context.font = `${weight} ${size}px ${font}`;
 
     // Computing positions without considering nodes sizes:
-    let sourceX = sourceData.x;
-    let sourceY = sourceData.y;
-    let targetX = targetData.x;
-    let targetY = targetData.y;
+    const ltr = sourceData.x < targetData.x;
+    let sourceX = ltr ? sourceData.x : targetData.x;
+    let sourceY = ltr ? sourceData.y : targetData.y;
+    let targetX = ltr ? targetData.x : sourceData.x;
+    let targetY = ltr ? targetData.y : sourceData.y;
     const centerX = (sourceX + targetX) / 2;
     const centerY = (sourceY + targetY) / 2;
     const diffX = targetX - sourceX;


### PR DESCRIPTION
## Pull request type

- [X] Feature

## What is the current behavior?

Issue Number: N/A

Curve labels appear in an unfavorable direction for reading if the source node is further to the right than the target node.

In the following video, Alice is the source node, Bob is the target node :

https://github.com/user-attachments/assets/1eb95039-1f64-41b5-8f98-aae7b74dbbe2

## What is the new behavior?

Curve labels appear in a direction that makes them easier to read, whatever the position of the source node in relation to the target node.

In the following video, Alice is the source node, Bob is the target node :

https://github.com/user-attachments/assets/b42133b9-bb42-42ff-8ba1-0719164483e2
