### PR TITLE
[layer-leaflet/maplibre] Fixing container resizing 

### DIFF
--- a/packages/layer-leaflet/src/index.ts
+++ b/packages/layer-leaflet/src/index.ts
@@ -26,9 +26,11 @@ export default function bindLeafletLayer(
   const prevSigmaSettings = sigma.getSettings();
 
   // Creating map container
-  const mapContainer = document.createElement("div");
-  mapContainer.classList.add("sigma-layer-leaflet");
-  mapContainer.setAttribute("style", "position: absolute; inset: 0; z-index: 0");
+  const mapContainer = sigma.createLayer("layer-leaflet", "div", {
+    style: { position: "absolute", inset: "0", zIndex: "0" },
+    // 'edges' is the first sigma layer
+    beforeLayer: "edges",
+  });
   sigma.getContainer().prepend(mapContainer);
 
   // Initialize the map
@@ -104,6 +106,7 @@ export default function bindLeafletLayer(
   // When sigma is resize, we need to update the graph coordinate (the ref has changed)
   // and recompute the zoom bounds
   function fnOnResize() {
+    map.invalidateSize();
     updateGraphCoordinates(sigma.getGraph());
     fnSyncSigmaWithMap();
     setSigmaRatioBounds(sigma, map);

--- a/packages/layer-maplibre/src/index.ts
+++ b/packages/layer-maplibre/src/index.ts
@@ -24,9 +24,11 @@ export default function bindMaplibreLayer(
   const prevSigmaSettings = sigma.getSettings();
 
   // Creating map container
-  const mapContainer = document.createElement("div");
-  mapContainer.classList.add("sigma-layer-maplibre");
-  mapContainer.setAttribute("style", "position: absolute; inset: 0");
+  const mapContainer = sigma.createLayer("layer-leaflet", "div", {
+    style: { position: "absolute", inset: "0" },
+    // 'edges' is the first sigma layer
+    beforeLayer: "edges",
+  });
   sigma.getContainer().prepend(mapContainer);
 
   // Initialize the map

--- a/packages/sigma/src/sigma.ts
+++ b/packages/sigma/src/sigma.ts
@@ -1904,8 +1904,6 @@ export default class Sigma<
     // If nothing has changed, we can stop right here
     if (!force && previousWidth === this.width && previousHeight === this.height) return this;
 
-    this.emit("resize");
-
     // Sizing dom elements
     for (const id in this.elements) {
       const element = this.elements[id];
@@ -1936,6 +1934,8 @@ export default class Sigma<
         if (currentTexture) gl.deleteTexture(currentTexture);
       }
     }
+
+    this.emit("resize");
 
     return this;
   }

--- a/packages/sigma/src/sigma.ts
+++ b/packages/sigma/src/sigma.ts
@@ -128,7 +128,7 @@ export default class Sigma<
   private mouseCaptor: MouseCaptor<N, E, G>;
   private touchCaptor: TouchCaptor<N, E, G>;
   private container: HTMLElement;
-  private elements: PlainObject<HTMLCanvasElement> = {};
+  private elements: PlainObject<HTMLElement> = {};
   private canvasContexts: PlainObject<CanvasRenderingContext2D> = {};
   private webGLContexts: PlainObject<WebGLRenderingContext> = {};
   private pickingLayers: Set<string> = new Set();
@@ -1518,6 +1518,46 @@ export default class Sigma<
   }
 
   /**
+   * Function used to create a layer element.
+   *
+   * @param {string} id - Context's id.
+   * @param {string} tag - The HTML tag to use.
+   * @param options
+   * @return {Sigma}
+   */
+  createLayer<T extends HTMLElement>(
+    id: string,
+    tag: string,
+    options: { style?: Partial<CSSStyleDeclaration> } & ({ beforeLayer?: string } | { afterLayer?: string }) = {},
+  ): T {
+    if (this.elements[id]) throw new Error(`Sigma: a layer named "${id}" already exists`);
+
+    const element = createElement<T>(
+      tag,
+      {
+        position: "absolute",
+      },
+      {
+        class: `sigma-${id}`,
+      },
+    );
+
+    if (options.style) Object.assign(element.style, options.style);
+
+    this.elements[id] = element;
+
+    if ("beforeLayer" in options && options.beforeLayer) {
+      this.elements[options.beforeLayer].before(element);
+    } else if ("afterLayer" in options && options.afterLayer) {
+      this.elements[options.afterLayer].after(element);
+    } else {
+      this.container.appendChild(element);
+    }
+
+    return element;
+  }
+
+  /**
    * Function used to create a canvas element.
    *
    * @param {string} id - Context's id.
@@ -1528,31 +1568,7 @@ export default class Sigma<
     id: string,
     options: { style?: Partial<CSSStyleDeclaration> } & ({ beforeLayer?: string } | { afterLayer?: string }) = {},
   ): HTMLCanvasElement {
-    if (this.elements[id]) throw new Error(`Sigma: a layer named "${id}" already exists`);
-
-    const canvas: HTMLCanvasElement = createElement<HTMLCanvasElement>(
-      "canvas",
-      {
-        position: "absolute",
-      },
-      {
-        class: `sigma-${id}`,
-      },
-    );
-
-    if (options.style) Object.assign(canvas.style, options.style);
-
-    this.elements[id] = canvas;
-
-    if ("beforeLayer" in options && options.beforeLayer) {
-      this.elements[options.beforeLayer].before(canvas);
-    } else if ("afterLayer" in options && options.afterLayer) {
-      this.elements[options.afterLayer].after(canvas);
-    } else {
-      this.container.appendChild(canvas);
-    }
-
-    return canvas;
+    return this.createLayer(id, "canvas", options);
   }
 
   /**
@@ -2328,9 +2344,9 @@ export default class Sigma<
    * - `hoverNodes`
    * - `mouse`
    *
-   * @return {PlainObject<HTMLCanvasElement>} - The collection of canvases.
+   * @return {PlainObject<HTMLElement>} - The collection of canvases.
    */
-  getCanvases(): PlainObject<HTMLCanvasElement> {
+  getCanvases(): PlainObject<HTMLElement> {
     return { ...this.elements };
   }
 }

--- a/packages/storybook/stories/3-additional-packages/layer-leaflet/basic.ts
+++ b/packages/storybook/stories/3-additional-packages/layer-leaflet/basic.ts
@@ -37,6 +37,12 @@ export default () => {
     getNodeLatLng: (attrs: Attributes) => ({ lat: attrs.latitude, lng: attrs.longitude }),
   });
 
+  const widthBtn = document.getElementById("change-width") as HTMLButtonElement;
+  widthBtn.addEventListener("click", () => {
+    container.style.width = 50 + Math.random() * 50 + "%";
+    renderer.resize(true);
+  });
+
   return () => {
     renderer.kill();
   };

--- a/packages/storybook/stories/3-additional-packages/layer-leaflet/index.html
+++ b/packages/storybook/stories/3-additional-packages/layer-leaflet/index.html
@@ -11,5 +11,7 @@
     z-index: 500;
   }
 </style>
-<div id="sigma-container"></div>
+<div id="sigma-container">
+  <button id="change-width" style="z-index:999;position: absolute;">Change width</button>
+</div>
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />

--- a/packages/storybook/stories/3-additional-packages/layer-maplibre/basic.ts
+++ b/packages/storybook/stories/3-additional-packages/layer-maplibre/basic.ts
@@ -37,6 +37,12 @@ export default () => {
     getNodeLatLng: (attrs: Attributes) => ({ lat: attrs.latitude, lng: attrs.longitude }),
   });
 
+  const widthBtn = document.getElementById("change-width") as HTMLButtonElement;
+  widthBtn.addEventListener("click", () => {
+    container.style.width = 50 + Math.random() * 50 + "%";
+    renderer.resize(true);
+  });
+
   return () => {
     renderer.kill();
   };

--- a/packages/storybook/stories/3-additional-packages/layer-maplibre/index.html
+++ b/packages/storybook/stories/3-additional-packages/layer-maplibre/index.html
@@ -11,5 +11,7 @@
     z-index: 500;
   }
 </style>
-<div id="sigma-container"></div>
+<div id="sigma-container">
+  <button id="change-width" style="z-index:999;position: absolute;">Change width</button>
+</div>
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.5.0/dist/maplibre-gl.css" />


### PR DESCRIPTION
# Description 

When the container height/width changed (programmatically, ie not a resize event), the map layer was not updated or badly. 
A "Change width" button has been added on the map layer stories to reproduce the issue.

# Changes

## Sigma 

- Adding the function `createLayer` function to allow to specify the HTML tag we want to create
- Emitting the sigma `resize` event when the resize is applied

## layer-leaflet & layer-maplibre

- using the `createLayer` function to create the `div` map container
- on leaflet, invalidate the map size in the resize function
