### PR TITLE
[sigma,layer-leaflet/maplibre] using `killLayer` to properly remove m…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27342,7 +27342,7 @@
     },
     "packages/layer-leaflet": {
       "name": "@sigma/layer-leaflet",
-      "version": "3.0.0-beta.8",
+      "version": "3.0.0-beta.9",
       "license": "MIT",
       "devDependencies": {
         "@types/leaflet": "^1.9.12"
@@ -27354,7 +27354,7 @@
     },
     "packages/layer-maplibre": {
       "name": "@sigma/layer-maplibre",
-      "version": "3.0.0-beta.7",
+      "version": "3.0.0-beta.8",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": "^4.5.0",
@@ -27402,7 +27402,7 @@
       }
     },
     "packages/sigma": {
-      "version": "3.0.0-beta.36",
+      "version": "3.0.0-beta.37",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",

--- a/packages/layer-leaflet/package.json
+++ b/packages/layer-leaflet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigma/layer-leaflet",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "description": "A plugin to set a geographical map in background",
   "main": "dist/sigma-layer-leaflet.cjs.js",
   "module": "dist/sigma-layer-leaflet.esm.js",

--- a/packages/layer-leaflet/src/index.ts
+++ b/packages/layer-leaflet/src/index.ts
@@ -26,7 +26,8 @@ export default function bindLeafletLayer(
   const prevSigmaSettings = sigma.getSettings();
 
   // Creating map container
-  const mapContainer = sigma.createLayer("layer-leaflet", "div", {
+  const mapLayerName = "layer-leaflet";
+  const mapContainer = sigma.createLayer(mapLayerName, "div", {
     style: { position: "absolute", inset: "0", zIndex: "0" },
     // 'edges' is the first sigma layer
     beforeLayer: "edges",
@@ -118,7 +119,8 @@ export default function bindLeafletLayer(
       isKilled = true;
 
       map.remove();
-      mapContainer.remove();
+
+      sigma.killLayer(mapLayerName);
 
       sigma.off("afterRender", fnSyncMapWithSigma);
       sigma.off("resize", fnOnResize);

--- a/packages/layer-maplibre/package.json
+++ b/packages/layer-maplibre/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigma/layer-maplibre",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.8",
   "description": "A plugin to set a geographical map in background",
   "main": "dist/sigma-layer-maplibre.cjs.js",
   "module": "dist/sigma-layer-maplibre.esm.js",

--- a/packages/layer-maplibre/src/index.ts
+++ b/packages/layer-maplibre/src/index.ts
@@ -24,7 +24,8 @@ export default function bindMaplibreLayer(
   const prevSigmaSettings = sigma.getSettings();
 
   // Creating map container
-  const mapContainer = sigma.createLayer("layer-leaflet", "div", {
+  const mapLayerName = "layer-maplibre";
+  const mapContainer = sigma.createLayer(mapLayerName, "div", {
     style: { position: "absolute", inset: "0" },
     // 'edges' is the first sigma layer
     beforeLayer: "edges",
@@ -100,7 +101,8 @@ export default function bindMaplibreLayer(
 
       map.off("moveend", fnSyncSigmaWithMap);
       map.remove();
-      mapContainer.remove();
+
+      sigma.killLayer(mapLayerName);
 
       sigma.off("afterRender", fnSyncMapWithSigma);
       sigma.off("resize", fnOnResize);

--- a/packages/sigma/package.json
+++ b/packages/sigma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigma",
-  "version": "3.0.0-beta.36",
+  "version": "3.0.0-beta.37",
   "description": "A JavaScript library aimed at visualizing graphs of thousands of nodes and edges.",
   "homepage": "https://www.sigmajs.org",
   "bugs": "http://github.com/jacomyal/sigma.js/issues",

--- a/packages/sigma/src/sigma.ts
+++ b/packages/sigma/src/sigma.ts
@@ -1645,26 +1645,26 @@ export default class Sigma<
   }
 
   /**
-   * Function used to properly kill a canvas layer.
+   * Function used to properly kill a layer.
    *
    * @param  {string} id - Layer id.
    * @return {Sigma}
    */
   killLayer(id: string): this {
-    const canvas = this.elements[id];
+    const element = this.elements[id];
 
-    if (!canvas) throw new Error(`Sigma: cannot kill layer ${id}, which does not exist`);
+    if (!element) throw new Error(`Sigma: cannot kill layer ${id}, which does not exist`);
 
     if (this.webGLContexts[id]) {
       const gl = this.webGLContexts[id];
       gl.getExtension("WEBGL_lose_context")?.loseContext();
       delete this.webGLContexts[id];
-    } else {
+    } else if (this.canvasContexts[id]) {
       delete this.canvasContexts[id];
     }
 
-    // Delete canvas:
-    canvas.remove();
+    // Delete layer element
+    element.remove();
     delete this.elements[id];
 
     return this;


### PR DESCRIPTION
# Description

If you  :
- create a graph with a map layer 
- then remove the map with `clean` function provided by the plugin
- recreate a map layer

Then you will  have an error : `a layer named "layer-leaflet" already exists.`

# Fix

- Change the `killLayer` to allow removing none canvas/webgl layers which can be created by `createLayer`.
- Using `killLayer` to properly remove map container

