### PR TITLE
[sigma] fix kill function

### DIFF
--- a/packages/sigma/src/sigma.ts
+++ b/packages/sigma/src/sigma.ts
@@ -2392,11 +2392,6 @@ export default class Sigma<
 
     while (container.firstChild) container.removeChild(container.firstChild);
 
-    // Destroying remaining collections
-    this.canvasContexts = {};
-    this.webGLContexts = {};
-    this.elements = {};
-
     // Kill programs:
     for (const type in this.nodePrograms) {
       this.nodePrograms[type].kill();
@@ -2415,6 +2410,11 @@ export default class Sigma<
     for (const id in this.elements) {
       this.killLayer(id);
     }
+
+    // Destroying remaining collections
+    this.canvasContexts = {};
+    this.webGLContexts = {};
+    this.elements = {};
   }
 
   /**


### PR DESCRIPTION
When calling the kill function, webgl contexts were not 'killed' by sigmajs.