### PR TITLE
[node-piechart] Check if the number of slices reaches the WebGL limit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 **[Website](https://www.sigmajs.org/)** | **[Documentation](https://www.sigmajs.org/docs)** | **[Storybook](https://www.sigmajs.org/storybook)** | <strong><a rel="me" href="https://vis.social/@sigmajs">Mastodon</a></strong>
 
+> [!NOTE]
+> Sigma v4 is now available as an alpha release. See [v4.sigmajs.org](https://v4.sigmajs.org/) for the website, or the [`v4` branch](https://github.com/jacomyal/sigma.js/tree/v4) for the source code.
+
 ---
 
 [Sigma.js](https://www.sigmajs.org) is an open-source JavaScript library aimed at visualizing graphs of thousands of nodes and edges using WebGL, mainly developed by [@jacomyal](https://github.com/jacomyal) and [@Yomguithereal](https://github.com/Yomguithereal), and built on top of [graphology](https://graphology.github.io/).

--- a/packages/node-piechart/src/factory.ts
+++ b/packages/node-piechart/src/factory.ts
@@ -63,6 +63,37 @@ export default function createNodePiechartProgram<
       };
     }
 
+    /**
+     * Overrides the default `getProgramInfo` to check if the user reach the webgl limitation about the number of vertex attributes.
+     */
+    getProgramInfo(
+      name: "normal" | "pick",
+      gl: WebGLRenderingContext | WebGL2RenderingContext,
+      vertexShaderSource: string,
+      fragmentShaderSource: string,
+      frameBuffer: WebGLFramebuffer | null,
+    ): ProgramInfo {
+      // Counting the number of needed attributes in the vertex shader
+      // Base attributes: a_position, a_id, a_size, and constant a_angle.
+      let count = 4;
+      if ("attribute" in offset) count += 1;
+      count += slices.reduce((sum, { color, value }) => {
+        if ("attribute" in color) sum += 1;
+        if ("attribute" in value) sum += 1;
+        return sum;
+      }, 0);
+
+      const maxVertexAttributes = gl.getParameter(gl.MAX_VERTEX_ATTRIBS) as number;
+
+      // Checking if the limit is reached
+      if (count > maxVertexAttributes)
+        throw new Error(
+          `createNodePiechartProgram: Too many slices. The node program requires ${count} vertex attributes, but the current WebGL context only supports ${maxVertexAttributes}. Please reduce the number of slices.`,
+        );
+
+      return super.getProgramInfo(name, gl, vertexShaderSource, fragmentShaderSource, frameBuffer);
+    }
+
     processVisibleItem(nodeIndex: number, startIndex: number, data: NodeDisplayData) {
       const array = this.array;
 

--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -1,6 +1,4 @@
-/* global require */
 import type { StorybookConfig } from "@storybook/html-vite";
-import { dirname, join } from "path";
 import { mergeConfig } from "vite";
 
 /** @type { import('@storybook/html-vite').StorybookConfig } */
@@ -8,9 +6,9 @@ const config: StorybookConfig = {
   stories: ["../stories/**/*.mdx", "../stories/**/stories.ts"],
   addons: [
     { name: "@storybook/addon-essentials", options: { actions: false, controls: false } },
-    getAbsolutePath("@storybook/addon-storysource"),
+    "@storybook/addon-storysource",
   ],
-  framework: getAbsolutePath("@storybook/html-vite"),
+  framework: "@storybook/html-vite",
   typescript: {
     check: true,
   },
@@ -28,7 +26,3 @@ const config: StorybookConfig = {
   },
 };
 export default config;
-
-function getAbsolutePath(value: string) {
-  return dirname(require.resolve(join(value, "package.json")));
-}

--- a/packages/website/static/homepage.html
+++ b/packages/website/static/homepage.html
@@ -15,6 +15,10 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
+    <div class="v4-notice">
+      This is the <strong>v3</strong> website.
+      <a href="https://v4.sigmajs.org">Looking for documentation for the <strong>alpha v4 version</strong>?</a>
+    </div>
     <header>
       <input type="checkbox" id="toggle-menu" />
       <nav class="menu">

--- a/packages/website/static/styles.css
+++ b/packages/website/static/styles.css
@@ -128,8 +128,9 @@ header {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  position: fixed;
+  position: sticky;
   z-index: 1;
+  top: 0;
   left: 0;
   right: 0;
   height: 0;
@@ -527,4 +528,17 @@ footer ul {
     display: block;
     text-align: center;
   }
+}
+
+.v4-notice {
+  background: #f9f7ed;
+  text-align: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  border-bottom: 1px solid #ccc;
+  line-height: 1.75;
+}
+.v4-notice a {
+  color: var(--ruby);
+  white-space: nowrap;
 }


### PR DESCRIPTION
See #1537

Slice values are stored in vertex attributes, but WebGL imposes a limit on the number of attributes available to a vertex shader. 

This commit adds a check for this limitation and returns a clear error message when the limit is exceeded.

A story is availbe on this branch to test it : `bsi/nodepiechart-vertex-attibutes-storybook`
