### PR TITLE
[codex] Make IcebugSigmaGraph CSR-backed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@ladybugmem/icebug": "^12.8.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.26.0",
         "@babel/preset-typescript": "^7.26.0",
@@ -5033,9 +5036,9 @@
       }
     },
     "node_modules/@ladybugmem/icebug": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@ladybugmem/icebug/-/icebug-12.7.0.tgz",
-      "integrity": "sha512-09MSrJi/QtXUHw2wmQYj4+W29d+qj1ZU9g3GuRhkWR7dEooxwkAtosmh8n0vArhusQqy7h3jaHMXMxPlVOdM7Q==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/@ladybugmem/icebug/-/icebug-12.8.0.tgz",
+      "integrity": "sha512-9gAi0d/T5x2EW9e3leJO5A/fDeqHsvw4Z0/Np4q2PVyH662fz2ZqIwtnEjqItoGXAf5o19PaXYB0WzGJ2rCWGQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5032,6 +5032,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@ladybugmem/icebug": {
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/@ladybugmem/icebug/-/icebug-12.7.0.tgz",
+      "integrity": "sha512-09MSrJi/QtXUHw2wmQYj4+W29d+qj1ZU9g3GuRhkWR7dEooxwkAtosmh8n0vArhusQqy7h3jaHMXMxPlVOdM7Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -7677,6 +7690,15 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -7974,6 +7996,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-3.1.1.tgz",
       "integrity": "sha512-SFCr4edNkZ1bGaLzGz7rgR1bRzVX4MmMxwsIa3/Bh6ose8v+hRpneoizHv0KChdjxaXyjRtaMq7sCuZSzPomQA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "license": "MIT"
     },
     "node_modules/@types/connect": {
@@ -9502,6 +9536,41 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -9529,6 +9598,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -10614,6 +10692,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -11057,6 +11150,44 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/commander": {
@@ -15208,6 +15339,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -15246,6 +15394,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.3.2",
@@ -18974,6 +19128,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -19762,6 +19924,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -22880,6 +23048,15 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-domexception": {
@@ -29489,6 +29666,19 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -30285,6 +30475,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/uc.micro": {
@@ -33140,6 +33339,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -33650,8 +33858,9 @@
       "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
-        "events": "^3.3.0",
-        "graphology-utils": "^2.5.2"
+        "@ladybugmem/icebug": "^12.7.0",
+        "apache-arrow": "^21.1.0",
+        "events": "^3.3.0"
       },
       "devDependencies": {
         "vite": "^6.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "@ladybugmem/icebug": "^12.8.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.26.0",
         "@babel/preset-typescript": "^7.26.0",
@@ -5033,19 +5030,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@ladybugmem/icebug": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@ladybugmem/icebug/-/icebug-12.8.0.tgz",
-      "integrity": "sha512-9gAi0d/T5x2EW9e3leJO5A/fDeqHsvw4Z0/Np4q2PVyH662fz2ZqIwtnEjqItoGXAf5o19PaXYB0WzGJ2rCWGQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -23053,15 +23037,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
-      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -33861,7 +33836,6 @@
       "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
-        "@ladybugmem/icebug": "^12.7.0",
         "apache-arrow": "^21.1.0",
         "events": "^3.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,5 @@
       "importConditionDefaultExport": "default"
     }
   },
-  "dependencies": {
-    "@ladybugmem/icebug": "^12.8.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "exports": {
       "importConditionDefaultExport": "default"
     }
+  },
+  "dependencies": {
+    "@ladybugmem/icebug": "^12.8.0"
   }
 }

--- a/packages/sigma/icebug/package.json
+++ b/packages/sigma/icebug/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/sigma-icebug.cjs.js",
+  "module": "dist/sigma-icebug.esm.js"
+}

--- a/packages/sigma/package.json
+++ b/packages/sigma/package.json
@@ -9,6 +9,7 @@
   "types": "dist/sigma.cjs.d.ts",
   "files": [
     "/dist",
+    "/icebug",
     "/types",
     "/settings",
     "/rendering",
@@ -39,8 +40,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "events": "^3.3.0",
-    "graphology-utils": "^2.5.2"
+    "@ladybugmem/icebug": "^12.7.0",
+    "apache-arrow": "^21.1.0",
+    "events": "^3.3.0"
   },
   "devDependencies": {
     "vite": "^6.0.7"
@@ -56,6 +58,7 @@
   "preconstruct": {
     "entrypoints": [
       "index.ts",
+      "icebug.ts",
       "types.ts",
       "settings.ts",
       "rendering/index.ts",
@@ -72,6 +75,11 @@
       "module": "./types/dist/sigma-types.esm.js",
       "import": "./types/dist/sigma-types.cjs.mjs",
       "default": "./types/dist/sigma-types.cjs.js"
+    },
+    "./icebug": {
+      "module": "./icebug/dist/sigma-icebug.esm.js",
+      "import": "./icebug/dist/sigma-icebug.cjs.mjs",
+      "default": "./icebug/dist/sigma-icebug.cjs.js"
     },
     "./settings": {
       "module": "./settings/dist/sigma-settings.esm.js",

--- a/packages/sigma/package.json
+++ b/packages/sigma/package.json
@@ -40,7 +40,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@ladybugmem/icebug": "^12.7.0",
     "apache-arrow": "^21.1.0",
     "events": "^3.3.0"
   },

--- a/packages/sigma/src/core/captors/captor.ts
+++ b/packages/sigma/src/core/captors/captor.ts
@@ -3,7 +3,7 @@
  * ======================
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../graph";
 
 import Sigma from "../../sigma";
 import { Coordinates, EventsMapping, MouseCoords, TouchCoords, TypedEventEmitter, WheelCoords } from "../../types";

--- a/packages/sigma/src/core/captors/mouse.ts
+++ b/packages/sigma/src/core/captors/mouse.ts
@@ -5,7 +5,7 @@
  * Sigma's captor dealing with the user's mouse.
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../graph";
 
 import { DEFAULT_SETTINGS, Settings } from "../../settings";
 import Sigma from "../../sigma";

--- a/packages/sigma/src/core/captors/touch.ts
+++ b/packages/sigma/src/core/captors/touch.ts
@@ -5,7 +5,7 @@
  * Sigma's captor dealing with touch.
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../graph";
 
 import { DEFAULT_SETTINGS, Settings } from "../../settings";
 import Sigma from "../../sigma";

--- a/packages/sigma/src/core/labels.ts
+++ b/packages/sigma/src/core/labels.ts
@@ -5,8 +5,7 @@
  * Miscellaneous heuristics related to label display.
  * @module
  */
-import Graph from "graphology-types";
-
+import { SigmaGraph } from "../graph";
 import { Coordinates, Dimensions } from "../types";
 
 /**
@@ -128,7 +127,7 @@ export class LabelGrid {
 export function edgeLabelsToDisplayFromNodes(params: {
   displayedNodeLabels: Set<string>;
   highlightedNodes: Set<string>;
-  graph: Graph;
+  graph: SigmaGraph;
   hoveredNode: string | null;
 }): Array<string> {
   const { graph, hoveredNode, highlightedNodes, displayedNodeLabels } = params;

--- a/packages/sigma/src/graph.ts
+++ b/packages/sigma/src/graph.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from "events";
+
+export type Attributes = Record<string, unknown>;
+
+export type GraphEventPayload = {
+  key: string;
+  attributes?: Attributes;
+  source?: string;
+  target?: string;
+  hints?: { attributes?: string[] };
+};
+
+export type GraphEvent =
+  | "nodeAdded"
+  | "nodeDropped"
+  | "nodeAttributesUpdated"
+  | "eachNodeAttributesUpdated"
+  | "edgeAdded"
+  | "edgeDropped"
+  | "edgeAttributesUpdated"
+  | "eachEdgeAttributesUpdated"
+  | "edgesCleared"
+  | "cleared";
+
+export interface SigmaGraph<
+  N extends Attributes = Attributes,
+  E extends Attributes = Attributes,
+  G extends Attributes = Attributes,
+> extends Pick<EventEmitter, "on" | "removeListener"> {
+  order: number;
+  size: number;
+  attributes?: G;
+
+  nodes(): string[];
+  edges(): string[];
+  forEachNode(callback: (node: string, attributes: N) => void): void;
+  forEachEdge(callback: (edge: string, attributes: E, source: string, target: string, sourceAttributes: N, targetAttributes: N) => void): void;
+  filterNodes(callback: (node: string, attributes: N) => boolean): string[];
+
+  hasNode(node: string): boolean;
+  hasEdge(edge: string): boolean;
+  source(edge: string): string;
+  target(edge: string): string;
+  extremities(edge: string): [string, string];
+  getNodeAttributes(node: string): N;
+  getNodeAttribute(node: string, name: string): unknown;
+  setNodeAttribute(node: string, name: string, value: unknown): void;
+  getEdgeAttributes(edge: string): E;
+}

--- a/packages/sigma/src/icebug.ts
+++ b/packages/sigma/src/icebug.ts
@@ -1,0 +1,281 @@
+import { EventEmitter } from "events";
+import { tableFromArrays, type Table } from "apache-arrow";
+import { GraphR, type GraphR as IcebugGraphR } from "@ladybugmem/icebug";
+
+import { Attributes, SigmaGraph } from "./graph";
+
+type NodeInput<N extends Attributes> = { key: string; attributes: N };
+type EdgeInput<E extends Attributes> = { key?: string; source: string; target: string; attributes?: E };
+
+type EdgeRecord<E extends Attributes> = {
+  key: string;
+  source: string;
+  target: string;
+  attributes: E;
+};
+
+export type IcebugSigmaGraphOptions<N extends Attributes, E extends Attributes> = {
+  directed?: boolean;
+  nodes?: Array<NodeInput<N>>;
+  edges?: Array<EdgeInput<E>>;
+};
+
+function toBigUint64Array(values: number[]): BigUint64Array {
+  const result = new BigUint64Array(values.length);
+  for (let i = 0; i < values.length; i++) result[i] = BigInt(values[i]);
+  return result;
+}
+
+function getColumn<T>(rows: Attributes[], key: string, fallback: T): T[] {
+  return rows.map((row) => (row[key] === undefined ? fallback : (row[key] as T)));
+}
+
+function buildTable(rows: Attributes[], columns: Record<string, unknown[]>): Table {
+  return tableFromArrays(columnsForRows(rows, columns));
+}
+
+function columnsForRows(rows: Attributes[], columns: Record<string, unknown[]>): Record<string, unknown[]> {
+  const result = { ...columns };
+  const keys = new Set<string>();
+  rows.forEach((row) => Object.keys(row).forEach((key) => keys.add(key)));
+  keys.forEach((key) => {
+    if (!result[key]) result[key] = getColumn(rows, key, null);
+  });
+  return result;
+}
+
+/**
+ * Sigma-compatible graph backed by Icebug's Arrow CSR graph for algorithms and
+ * Apache Arrow tables for visualization data exchange.
+ */
+export class IcebugSigmaGraph<
+  N extends Attributes = Attributes,
+  E extends Attributes = Attributes,
+  G extends Attributes = Attributes,
+> extends EventEmitter implements SigmaGraph<N, E, G> {
+  attributes?: G;
+
+  readonly directed: boolean;
+  private nodeOrder: string[] = [];
+  private nodeIndex: Map<string, number> = new Map();
+  private nodeAttributes: Map<string, N> = new Map();
+  private edgeOrder: string[] = [];
+  private edgeRecords: Map<string, EdgeRecord<E>> = new Map();
+  private edgePairIndex: Map<string, string> = new Map();
+
+  nodeTable: Table = tableFromArrays({ key: [] });
+  edgeTable: Table = tableFromArrays({ key: [], source: [], target: [], sourceIndex: [], targetIndex: [] });
+  icebugGraph: IcebugGraphR = new GraphR(0, true, new BigUint64Array(), new BigUint64Array([0n]), new BigUint64Array(), new BigUint64Array([0n]));
+
+  constructor(options: IcebugSigmaGraphOptions<N, E> = {}) {
+    super();
+    this.directed = options.directed ?? true;
+    options.nodes?.forEach(({ key, attributes }) => this.addNode(key, attributes, false));
+    options.edges?.forEach(({ key, source, target, attributes }) => this.addEdge(key ?? `${source}->${target}`, source, target, attributes ?? ({} as E), false));
+    this.rebuildColumnarData();
+  }
+
+  get order(): number {
+    return this.nodeOrder.length;
+  }
+
+  get size(): number {
+    return this.edgeOrder.length;
+  }
+
+  nodes(): string[] {
+    return this.nodeOrder.slice();
+  }
+
+  edges(): string[] {
+    return this.edgeOrder.slice();
+  }
+
+  forEachNode(callback: (node: string, attributes: N) => void): void {
+    this.nodeOrder.forEach((node) => callback(node, this.getNodeAttributes(node)));
+  }
+
+  forEachEdge(callback: (edge: string, attributes: E, source: string, target: string, sourceAttributes: N, targetAttributes: N) => void): void {
+    this.edgeOrder.forEach((edge) => {
+      const record = this.getEdgeRecord(edge);
+      callback(edge, record.attributes, record.source, record.target, this.getNodeAttributes(record.source), this.getNodeAttributes(record.target));
+    });
+  }
+
+  filterNodes(callback: (node: string, attributes: N) => boolean): string[] {
+    return this.nodeOrder.filter((node) => callback(node, this.getNodeAttributes(node)));
+  }
+
+  hasNode(node: string): boolean {
+    return this.nodeIndex.has(node);
+  }
+
+  hasEdge(edge: string): boolean {
+    return this.edgeRecords.has(edge);
+  }
+
+  source(edge: string): string {
+    return this.getEdgeRecord(edge).source;
+  }
+
+  target(edge: string): string {
+    return this.getEdgeRecord(edge).target;
+  }
+
+  extremities(edge: string): [string, string] {
+    const record = this.getEdgeRecord(edge);
+    return [record.source, record.target];
+  }
+
+  getNodeAttributes(node: string): N {
+    const attributes = this.nodeAttributes.get(node);
+    if (!attributes) throw new Error(`IcebugSigmaGraph: node "${node}" not found.`);
+    return attributes;
+  }
+
+  getNodeAttribute(node: string, name: string): unknown {
+    return this.getNodeAttributes(node)[name];
+  }
+
+  getEdgeAttributes(edge: string): E {
+    return this.getEdgeRecord(edge).attributes;
+  }
+
+  addNode(key: string, attributes = {} as N, emit = true): void {
+    if (this.hasNode(key)) throw new Error(`IcebugSigmaGraph: node "${key}" already exists.`);
+    this.nodeIndex.set(key, this.nodeOrder.length);
+    this.nodeOrder.push(key);
+    this.nodeAttributes.set(key, attributes);
+    if (emit) {
+      this.rebuildColumnarData();
+      this.emit("nodeAdded", { key, attributes });
+    }
+  }
+
+  addEdge(key: string, source: string, target: string, attributes = {} as E, emit = true): void {
+    if (!this.hasNode(source)) this.addNode(source, {} as N, false);
+    if (!this.hasNode(target)) this.addNode(target, {} as N, false);
+    if (this.hasEdge(key)) throw new Error(`IcebugSigmaGraph: edge "${key}" already exists.`);
+
+    const record = { key, source, target, attributes };
+    this.edgeOrder.push(key);
+    this.edgeRecords.set(key, record);
+    this.edgePairIndex.set(`${source}\u0000${target}`, key);
+    if (!this.directed) this.edgePairIndex.set(`${target}\u0000${source}`, key);
+
+    if (emit) {
+      this.rebuildColumnarData();
+      this.emit("edgeAdded", { key, source, target, attributes });
+    }
+  }
+
+  setNodeAttribute(node: string, name: string, value: unknown): void {
+    const attributes = { ...this.getNodeAttributes(node), [name]: value } as N;
+    this.nodeAttributes.set(node, attributes);
+    this.rebuildNodeTable();
+    this.emit("nodeAttributesUpdated", { key: node, attributes, hints: { attributes: [name] } });
+  }
+
+  setEdgeAttribute(edge: string, name: string, value: unknown): void {
+    const record = this.getEdgeRecord(edge);
+    record.attributes = { ...record.attributes, [name]: value } as E;
+    this.edgeRecords.set(edge, record);
+    this.rebuildEdgeTable();
+    this.emit("edgeAttributesUpdated", { key: edge, attributes: record.attributes, hints: { attributes: [name] } });
+  }
+
+  degree(node: string): number {
+    const index = this.nodeIndex.get(node);
+    if (index === undefined) return 0;
+    return this.icebugGraph.degree(index);
+  }
+
+  neighbors(node: string): string[] {
+    const index = this.nodeIndex.get(node);
+    if (index === undefined) return [];
+    return this.icebugGraph.neighbors(index).map((neighbor) => this.nodeOrder[neighbor]);
+  }
+
+  private getEdgeRecord(edge: string): EdgeRecord<E> {
+    const record = this.edgeRecords.get(edge);
+    if (!record) throw new Error(`IcebugSigmaGraph: edge "${edge}" not found.`);
+    return record;
+  }
+
+  private rebuildColumnarData(): void {
+    this.rebuildNodeTable();
+    this.rebuildEdgeTable();
+    this.rebuildIcebugGraph();
+  }
+
+  private rebuildNodeTable(): void {
+    const rows = this.nodeOrder.map((key) => this.getNodeAttributes(key));
+    this.nodeTable = buildTable(rows, {
+      key: this.nodeOrder,
+      x: getColumn(rows, "x", null),
+      y: getColumn(rows, "y", null),
+      size: getColumn(rows, "size", null),
+      color: getColumn(rows, "color", null),
+      label: getColumn(rows, "label", null),
+    });
+  }
+
+  private rebuildEdgeTable(): void {
+    const records = this.edgeOrder.map((edge) => this.getEdgeRecord(edge));
+    const rows = records.map((record) => record.attributes);
+    this.edgeTable = buildTable(rows, {
+      key: records.map((record) => record.key),
+      source: records.map((record) => record.source),
+      target: records.map((record) => record.target),
+      sourceIndex: records.map((record) => this.nodeIndex.get(record.source) ?? -1),
+      targetIndex: records.map((record) => this.nodeIndex.get(record.target) ?? -1),
+      size: getColumn(rows, "size", null),
+      color: getColumn(rows, "color", null),
+      label: getColumn(rows, "label", null),
+    });
+  }
+
+  private rebuildIcebugGraph(): void {
+    const n = this.nodeOrder.length;
+    const out: number[][] = Array.from({ length: n }, () => []);
+    const incoming: number[][] = Array.from({ length: n }, () => []);
+
+    this.edgeOrder.forEach((edge) => {
+      const { source, target } = this.getEdgeRecord(edge);
+      const sourceIndex = this.nodeIndex.get(source);
+      const targetIndex = this.nodeIndex.get(target);
+      if (sourceIndex === undefined || targetIndex === undefined) return;
+      out[sourceIndex].push(targetIndex);
+      incoming[targetIndex].push(sourceIndex);
+      if (!this.directed) {
+        out[targetIndex].push(sourceIndex);
+        incoming[sourceIndex].push(targetIndex);
+      }
+    });
+
+    const outIndices: number[] = [];
+    const outIndptr = [0];
+    out.forEach((neighbors) => {
+      outIndices.push(...neighbors);
+      outIndptr.push(outIndices.length);
+    });
+
+    const inIndices: number[] = [];
+    const inIndptr = [0];
+    incoming.forEach((neighbors) => {
+      inIndices.push(...neighbors);
+      inIndptr.push(inIndices.length);
+    });
+
+    this.icebugGraph = new GraphR(
+      n,
+      this.directed,
+      toBigUint64Array(outIndices),
+      toBigUint64Array(outIndptr),
+      toBigUint64Array(inIndices),
+      toBigUint64Array(inIndptr),
+    );
+  }
+}
+
+export default IcebugSigmaGraph;

--- a/packages/sigma/src/icebug.ts
+++ b/packages/sigma/src/icebug.ts
@@ -1,29 +1,41 @@
 import { EventEmitter } from "events";
 import { tableFromArrays, type Table } from "apache-arrow";
-import { GraphR, type GraphR as IcebugGraphR } from "@ladybugmem/icebug";
 
 import { Attributes, SigmaGraph } from "./graph";
 
+type CSRArray = number[] | Uint32Array | BigUint64Array;
 type NodeInput<N extends Attributes> = { key: string; attributes: N };
 type EdgeInput<E extends Attributes> = { key?: string; source: string; target: string; attributes?: E };
 
-type EdgeRecord<E extends Attributes> = {
-  key: string;
-  source: string;
-  target: string;
-  attributes: E;
+export type IcebugSigmaGraphCSROptions<N extends Attributes, E extends Attributes> = {
+  directed?: boolean;
+  nodes: Array<NodeInput<N>>;
+  csr: {
+    indptr: CSRArray;
+    indices: CSRArray;
+    edgeIds?: CSRArray | null;
+  };
+  edgeAttributes?: E[];
+  edgeKeys?: string[];
 };
 
-export type IcebugSigmaGraphOptions<N extends Attributes, E extends Attributes> = {
+export type IcebugSigmaGraphEdgeListOptions<N extends Attributes, E extends Attributes> = {
   directed?: boolean;
   nodes?: Array<NodeInput<N>>;
   edges?: Array<EdgeInput<E>>;
 };
 
-function toBigUint64Array(values: number[]): BigUint64Array {
-  const result = new BigUint64Array(values.length);
-  for (let i = 0; i < values.length; i++) result[i] = BigInt(values[i]);
-  return result;
+export type IcebugSigmaGraphOptions<N extends Attributes, E extends Attributes> =
+  | IcebugSigmaGraphCSROptions<N, E>
+  | IcebugSigmaGraphEdgeListOptions<N, E>;
+
+function toNumber(value: number | bigint): number {
+  if (typeof value === "bigint") return Number(value);
+  return value;
+}
+
+function readCSRValue(values: CSRArray, index: number): number {
+  return toNumber(values[index] as number | bigint);
 }
 
 function getColumn<T>(rows: Attributes[], key: string, fallback: T): T[] {
@@ -31,22 +43,66 @@ function getColumn<T>(rows: Attributes[], key: string, fallback: T): T[] {
 }
 
 function buildTable(rows: Attributes[], columns: Record<string, unknown[]>): Table {
-  return tableFromArrays(columnsForRows(rows, columns));
-}
-
-function columnsForRows(rows: Attributes[], columns: Record<string, unknown[]>): Record<string, unknown[]> {
   const result = { ...columns };
   const keys = new Set<string>();
   rows.forEach((row) => Object.keys(row).forEach((key) => keys.add(key)));
   keys.forEach((key) => {
     if (!result[key]) result[key] = getColumn(rows, key, null);
   });
-  return result;
+  return tableFromArrays(result);
+}
+
+function isCSROptions<N extends Attributes, E extends Attributes>(
+  options: IcebugSigmaGraphOptions<N, E>,
+): options is IcebugSigmaGraphCSROptions<N, E> {
+  return "csr" in options;
+}
+
+function edgeListToCSR<N extends Attributes, E extends Attributes>(
+  nodes: Array<NodeInput<N>>,
+  edges: Array<EdgeInput<E>>,
+  directed: boolean,
+): IcebugSigmaGraphCSROptions<N, E> {
+  const nodeIndex = new Map(nodes.map((node, index) => [node.key, index]));
+  const outgoing: Array<Array<{ target: number; edgeIndex: number }>> = Array.from({ length: nodes.length }, () => []);
+
+  edges.forEach((edge, edgeIndex) => {
+    const source = nodeIndex.get(edge.source);
+    const target = nodeIndex.get(edge.target);
+    if (source === undefined || target === undefined) return;
+    outgoing[source].push({ target, edgeIndex });
+    if (!directed) outgoing[target].push({ target: source, edgeIndex });
+  });
+
+  const indptr = new BigUint64Array(nodes.length + 1);
+  const indices: bigint[] = [];
+  const edgeIds: bigint[] = [];
+  outgoing.forEach((neighbors, sourceIndex) => {
+    indptr[sourceIndex] = BigInt(indices.length);
+    neighbors.forEach(({ target, edgeIndex }) => {
+      indices.push(BigInt(target));
+      edgeIds.push(BigInt(edgeIndex));
+    });
+  });
+  indptr[nodes.length] = BigInt(indices.length);
+
+  return {
+    directed,
+    nodes,
+    csr: {
+      indptr,
+      indices: new BigUint64Array(indices),
+      edgeIds: new BigUint64Array(edgeIds),
+    },
+    edgeAttributes: edges.map((edge) => edge.attributes ?? ({} as E)),
+    edgeKeys: edges.map((edge, index) => edge.key ?? `${edge.source}->${edge.target}#${index}`),
+  };
 }
 
 /**
- * Sigma-compatible graph backed by Icebug's Arrow CSR graph for algorithms and
- * Apache Arrow tables for visualization data exchange.
+ * Sigma-compatible, browser-safe graph backed by CSR arrays and columnar
+ * metadata. This intentionally does not import @ladybugmem/icebug because that
+ * package is a Node native addon and cannot execute inside a Tauri WebView.
  */
 export class IcebugSigmaGraph<
   N extends Attributes = Attributes,
@@ -56,23 +112,58 @@ export class IcebugSigmaGraph<
   attributes?: G;
 
   readonly directed: boolean;
-  private nodeOrder: string[] = [];
-  private nodeIndex: Map<string, number> = new Map();
-  private nodeAttributes: Map<string, N> = new Map();
-  private edgeOrder: string[] = [];
-  private edgeRecords: Map<string, EdgeRecord<E>> = new Map();
-  private edgePairIndex: Map<string, string> = new Map();
+  readonly nodeTable: Table;
+  readonly edgeTable: Table;
 
-  nodeTable: Table = tableFromArrays({ key: [] });
-  edgeTable: Table = tableFromArrays({ key: [], source: [], target: [], sourceIndex: [], targetIndex: [] });
-  icebugGraph: IcebugGraphR = new GraphR(0, true, new BigUint64Array(), new BigUint64Array([0n]), new BigUint64Array(), new BigUint64Array([0n]));
+  private nodeOrder: string[];
+  private nodeIndex: Map<string, number>;
+  private nodeAttributes: N[];
+  private edgeOrder: string[];
+  private edgeIndex: Map<string, number>;
+  private edgeAttributes: E[];
+  private edgeSources: Uint32Array;
+  private edgeTargets: Uint32Array;
+  private outIndptr: CSRArray;
+  private outIndices: CSRArray;
 
   constructor(options: IcebugSigmaGraphOptions<N, E> = {}) {
     super();
-    this.directed = options.directed ?? true;
-    options.nodes?.forEach(({ key, attributes }) => this.addNode(key, attributes, false));
-    options.edges?.forEach(({ key, source, target, attributes }) => this.addEdge(key ?? `${source}->${target}`, source, target, attributes ?? ({} as E), false));
-    this.rebuildColumnarData();
+    const directed = options.directed ?? true;
+    const csrOptions = isCSROptions(options)
+      ? options
+      : edgeListToCSR(options.nodes ?? [], options.edges ?? [], directed);
+
+    this.directed = csrOptions.directed ?? true;
+    this.nodeOrder = csrOptions.nodes.map((node) => node.key);
+    this.nodeIndex = new Map(this.nodeOrder.map((key, index) => [key, index]));
+    this.nodeAttributes = csrOptions.nodes.map((node) => node.attributes ?? ({} as N));
+    this.outIndptr = csrOptions.csr.indptr;
+    this.outIndices = csrOptions.csr.indices;
+
+    const edgeCount = this.outIndices.length;
+    this.edgeSources = new Uint32Array(edgeCount);
+    this.edgeTargets = new Uint32Array(edgeCount);
+    this.edgeAttributes = Array.from({ length: edgeCount }, (_, index) => {
+      const edgeId = csrOptions.csr.edgeIds ? readCSRValue(csrOptions.csr.edgeIds, index) : index;
+      return csrOptions.edgeAttributes?.[edgeId] ?? ({} as E);
+    });
+    this.edgeOrder = Array.from({ length: edgeCount }, (_, index) => {
+      const edgeId = csrOptions.csr.edgeIds ? readCSRValue(csrOptions.csr.edgeIds, index) : index;
+      return csrOptions.edgeKeys?.[edgeId] ?? String(edgeId);
+    });
+
+    for (let source = 0; source < this.nodeOrder.length; source++) {
+      const start = readCSRValue(this.outIndptr, source);
+      const end = readCSRValue(this.outIndptr, source + 1);
+      for (let ptr = start; ptr < end; ptr++) {
+        this.edgeSources[ptr] = source;
+        this.edgeTargets[ptr] = readCSRValue(this.outIndices, ptr);
+      }
+    }
+
+    this.edgeIndex = new Map(this.edgeOrder.map((key, index) => [key, index]));
+    this.nodeTable = this.buildNodeTable();
+    this.edgeTable = this.buildEdgeTable();
   }
 
   get order(): number {
@@ -92,18 +183,26 @@ export class IcebugSigmaGraph<
   }
 
   forEachNode(callback: (node: string, attributes: N) => void): void {
-    this.nodeOrder.forEach((node) => callback(node, this.getNodeAttributes(node)));
+    this.nodeOrder.forEach((node, index) => callback(node, this.nodeAttributes[index]));
   }
 
   forEachEdge(callback: (edge: string, attributes: E, source: string, target: string, sourceAttributes: N, targetAttributes: N) => void): void {
-    this.edgeOrder.forEach((edge) => {
-      const record = this.getEdgeRecord(edge);
-      callback(edge, record.attributes, record.source, record.target, this.getNodeAttributes(record.source), this.getNodeAttributes(record.target));
+    this.edgeOrder.forEach((edge, index) => {
+      const sourceIndex = this.edgeSources[index];
+      const targetIndex = this.edgeTargets[index];
+      callback(
+        edge,
+        this.edgeAttributes[index],
+        this.nodeOrder[sourceIndex],
+        this.nodeOrder[targetIndex],
+        this.nodeAttributes[sourceIndex],
+        this.nodeAttributes[targetIndex],
+      );
     });
   }
 
   filterNodes(callback: (node: string, attributes: N) => boolean): string[] {
-    return this.nodeOrder.filter((node) => callback(node, this.getNodeAttributes(node)));
+    return this.nodeOrder.filter((node, index) => callback(node, this.nodeAttributes[index]));
   }
 
   hasNode(node: string): boolean {
@@ -111,170 +210,92 @@ export class IcebugSigmaGraph<
   }
 
   hasEdge(edge: string): boolean {
-    return this.edgeRecords.has(edge);
+    return this.edgeIndex.has(edge);
   }
 
   source(edge: string): string {
-    return this.getEdgeRecord(edge).source;
+    return this.nodeOrder[this.edgeSources[this.getEdgeIndex(edge)]];
   }
 
   target(edge: string): string {
-    return this.getEdgeRecord(edge).target;
+    return this.nodeOrder[this.edgeTargets[this.getEdgeIndex(edge)]];
   }
 
   extremities(edge: string): [string, string] {
-    const record = this.getEdgeRecord(edge);
-    return [record.source, record.target];
+    const index = this.getEdgeIndex(edge);
+    return [this.nodeOrder[this.edgeSources[index]], this.nodeOrder[this.edgeTargets[index]]];
   }
 
   getNodeAttributes(node: string): N {
-    const attributes = this.nodeAttributes.get(node);
-    if (!attributes) throw new Error(`IcebugSigmaGraph: node "${node}" not found.`);
-    return attributes;
+    return this.nodeAttributes[this.getNodeIndex(node)];
   }
 
   getNodeAttribute(node: string, name: string): unknown {
     return this.getNodeAttributes(node)[name];
   }
 
-  getEdgeAttributes(edge: string): E {
-    return this.getEdgeRecord(edge).attributes;
-  }
-
-  addNode(key: string, attributes = {} as N, emit = true): void {
-    if (this.hasNode(key)) throw new Error(`IcebugSigmaGraph: node "${key}" already exists.`);
-    this.nodeIndex.set(key, this.nodeOrder.length);
-    this.nodeOrder.push(key);
-    this.nodeAttributes.set(key, attributes);
-    if (emit) {
-      this.rebuildColumnarData();
-      this.emit("nodeAdded", { key, attributes });
-    }
-  }
-
-  addEdge(key: string, source: string, target: string, attributes = {} as E, emit = true): void {
-    if (!this.hasNode(source)) this.addNode(source, {} as N, false);
-    if (!this.hasNode(target)) this.addNode(target, {} as N, false);
-    if (this.hasEdge(key)) throw new Error(`IcebugSigmaGraph: edge "${key}" already exists.`);
-
-    const record = { key, source, target, attributes };
-    this.edgeOrder.push(key);
-    this.edgeRecords.set(key, record);
-    this.edgePairIndex.set(`${source}\u0000${target}`, key);
-    if (!this.directed) this.edgePairIndex.set(`${target}\u0000${source}`, key);
-
-    if (emit) {
-      this.rebuildColumnarData();
-      this.emit("edgeAdded", { key, source, target, attributes });
-    }
-  }
-
   setNodeAttribute(node: string, name: string, value: unknown): void {
-    const attributes = { ...this.getNodeAttributes(node), [name]: value } as N;
-    this.nodeAttributes.set(node, attributes);
-    this.rebuildNodeTable();
-    this.emit("nodeAttributesUpdated", { key: node, attributes, hints: { attributes: [name] } });
+    const index = this.getNodeIndex(node);
+    this.nodeAttributes[index] = { ...this.nodeAttributes[index], [name]: value };
+    this.emit("nodeAttributesUpdated", {
+      key: node,
+      attributes: this.nodeAttributes[index],
+      hints: { attributes: [name] },
+    });
   }
 
-  setEdgeAttribute(edge: string, name: string, value: unknown): void {
-    const record = this.getEdgeRecord(edge);
-    record.attributes = { ...record.attributes, [name]: value } as E;
-    this.edgeRecords.set(edge, record);
-    this.rebuildEdgeTable();
-    this.emit("edgeAttributesUpdated", { key: edge, attributes: record.attributes, hints: { attributes: [name] } });
+  getEdgeAttributes(edge: string): E {
+    return this.edgeAttributes[this.getEdgeIndex(edge)];
   }
 
   degree(node: string): number {
-    const index = this.nodeIndex.get(node);
-    if (index === undefined) return 0;
-    return this.icebugGraph.degree(index);
+    const index = this.getNodeIndex(node);
+    return readCSRValue(this.outIndptr, index + 1) - readCSRValue(this.outIndptr, index);
   }
 
   neighbors(node: string): string[] {
+    const index = this.getNodeIndex(node);
+    const start = readCSRValue(this.outIndptr, index);
+    const end = readCSRValue(this.outIndptr, index + 1);
+    const result: string[] = [];
+    for (let ptr = start; ptr < end; ptr++) result.push(this.nodeOrder[readCSRValue(this.outIndices, ptr)]);
+    return result;
+  }
+
+  private getNodeIndex(node: string): number {
     const index = this.nodeIndex.get(node);
-    if (index === undefined) return [];
-    return this.icebugGraph.neighbors(index).map((neighbor) => this.nodeOrder[neighbor]);
+    if (index === undefined) throw new Error(`IcebugSigmaGraph: node "${node}" not found.`);
+    return index;
   }
 
-  private getEdgeRecord(edge: string): EdgeRecord<E> {
-    const record = this.edgeRecords.get(edge);
-    if (!record) throw new Error(`IcebugSigmaGraph: edge "${edge}" not found.`);
-    return record;
+  private getEdgeIndex(edge: string): number {
+    const index = this.edgeIndex.get(edge);
+    if (index === undefined) throw new Error(`IcebugSigmaGraph: edge "${edge}" not found.`);
+    return index;
   }
 
-  private rebuildColumnarData(): void {
-    this.rebuildNodeTable();
-    this.rebuildEdgeTable();
-    this.rebuildIcebugGraph();
-  }
-
-  private rebuildNodeTable(): void {
-    const rows = this.nodeOrder.map((key) => this.getNodeAttributes(key));
-    this.nodeTable = buildTable(rows, {
+  private buildNodeTable(): Table {
+    return buildTable(this.nodeAttributes, {
       key: this.nodeOrder,
-      x: getColumn(rows, "x", null),
-      y: getColumn(rows, "y", null),
-      size: getColumn(rows, "size", null),
-      color: getColumn(rows, "color", null),
-      label: getColumn(rows, "label", null),
+      x: getColumn(this.nodeAttributes, "x", null),
+      y: getColumn(this.nodeAttributes, "y", null),
+      size: getColumn(this.nodeAttributes, "size", null),
+      color: getColumn(this.nodeAttributes, "color", null),
+      label: getColumn(this.nodeAttributes, "label", null),
     });
   }
 
-  private rebuildEdgeTable(): void {
-    const records = this.edgeOrder.map((edge) => this.getEdgeRecord(edge));
-    const rows = records.map((record) => record.attributes);
-    this.edgeTable = buildTable(rows, {
-      key: records.map((record) => record.key),
-      source: records.map((record) => record.source),
-      target: records.map((record) => record.target),
-      sourceIndex: records.map((record) => this.nodeIndex.get(record.source) ?? -1),
-      targetIndex: records.map((record) => this.nodeIndex.get(record.target) ?? -1),
-      size: getColumn(rows, "size", null),
-      color: getColumn(rows, "color", null),
-      label: getColumn(rows, "label", null),
+  private buildEdgeTable(): Table {
+    return buildTable(this.edgeAttributes, {
+      key: this.edgeOrder,
+      source: Array.from(this.edgeSources, (source) => this.nodeOrder[source]),
+      target: Array.from(this.edgeTargets, (target) => this.nodeOrder[target]),
+      sourceIndex: Array.from(this.edgeSources),
+      targetIndex: Array.from(this.edgeTargets),
+      size: getColumn(this.edgeAttributes, "size", null),
+      color: getColumn(this.edgeAttributes, "color", null),
+      label: getColumn(this.edgeAttributes, "label", null),
     });
-  }
-
-  private rebuildIcebugGraph(): void {
-    const n = this.nodeOrder.length;
-    const out: number[][] = Array.from({ length: n }, () => []);
-    const incoming: number[][] = Array.from({ length: n }, () => []);
-
-    this.edgeOrder.forEach((edge) => {
-      const { source, target } = this.getEdgeRecord(edge);
-      const sourceIndex = this.nodeIndex.get(source);
-      const targetIndex = this.nodeIndex.get(target);
-      if (sourceIndex === undefined || targetIndex === undefined) return;
-      out[sourceIndex].push(targetIndex);
-      incoming[targetIndex].push(sourceIndex);
-      if (!this.directed) {
-        out[targetIndex].push(sourceIndex);
-        incoming[sourceIndex].push(targetIndex);
-      }
-    });
-
-    const outIndices: number[] = [];
-    const outIndptr = [0];
-    out.forEach((neighbors) => {
-      outIndices.push(...neighbors);
-      outIndptr.push(outIndices.length);
-    });
-
-    const inIndices: number[] = [];
-    const inIndptr = [0];
-    incoming.forEach((neighbors) => {
-      inIndices.push(...neighbors);
-      inIndptr.push(inIndices.length);
-    });
-
-    this.icebugGraph = new GraphR(
-      n,
-      this.directed,
-      toBigUint64Array(outIndices),
-      toBigUint64Array(outIndptr),
-      toBigUint64Array(inIndices),
-      toBigUint64Array(inIndptr),
-    );
   }
 }
 

--- a/packages/sigma/src/index.ts
+++ b/packages/sigma/src/index.ts
@@ -12,3 +12,4 @@ import Sigma from "./sigma";
 
 export default Sigma;
 export { Sigma, Camera, MouseCaptor, TouchCaptor };
+export type { Attributes, SigmaGraph } from "./graph";

--- a/packages/sigma/src/rendering/edge-labels.ts
+++ b/packages/sigma/src/rendering/edge-labels.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "graphology-types";
+import { Attributes } from "../graph";
 
 import { Settings } from "../settings";
 import { EdgeDisplayData, NodeDisplayData, PartialButFor } from "../types";

--- a/packages/sigma/src/rendering/edge.ts
+++ b/packages/sigma/src/rendering/edge.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../graph";
 
 import Sigma from "../sigma";
 import { EdgeDisplayData, NodeDisplayData, RenderParams } from "../types";

--- a/packages/sigma/src/rendering/node-hover.ts
+++ b/packages/sigma/src/rendering/node-hover.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "graphology-types";
+import { Attributes } from "../graph";
 
 import { Settings } from "../settings";
 import { NodeDisplayData, PartialButFor } from "../types";

--- a/packages/sigma/src/rendering/node-labels.ts
+++ b/packages/sigma/src/rendering/node-labels.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "graphology-types";
+import { Attributes } from "../graph";
 
 import { Settings } from "../settings";
 import { NodeDisplayData, PartialButFor } from "../types";

--- a/packages/sigma/src/rendering/node.ts
+++ b/packages/sigma/src/rendering/node.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../graph";
 
 import Sigma from "../sigma";
 import { NodeDisplayData, NonEmptyArray, RenderParams } from "../types";

--- a/packages/sigma/src/rendering/program.ts
+++ b/packages/sigma/src/rendering/program.ts
@@ -5,7 +5,7 @@
  * Class representing a single WebGL program used by sigma's WebGL renderer.
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../graph";
 
 import type Sigma from "../sigma";
 import type { RenderParams } from "../types";

--- a/packages/sigma/src/rendering/programs/edge-arrow-head/index.ts
+++ b/packages/sigma/src/rendering/programs/edge-arrow-head/index.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { EdgeDisplayData, NodeDisplayData, RenderParams } from "../../../types";
 import { floatColor } from "../../../utils";

--- a/packages/sigma/src/rendering/programs/edge-arrow/index.ts
+++ b/packages/sigma/src/rendering/programs/edge-arrow/index.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { EdgeProgramType, createEdgeCompoundProgram } from "../../edge";
 import { CreateEdgeArrowHeadProgramOptions, createEdgeArrowHeadProgram } from "../edge-arrow-head";

--- a/packages/sigma/src/rendering/programs/edge-clamped/index.ts
+++ b/packages/sigma/src/rendering/programs/edge-clamped/index.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { EdgeDisplayData, NodeDisplayData, RenderParams } from "../../../types";
 import { floatColor } from "../../../utils";

--- a/packages/sigma/src/rendering/programs/edge-double-arrow/index.ts
+++ b/packages/sigma/src/rendering/programs/edge-double-arrow/index.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { EdgeProgramType, createEdgeCompoundProgram } from "../../edge";
 import { CreateEdgeArrowHeadProgramOptions, createEdgeArrowHeadProgram } from "../edge-arrow-head";

--- a/packages/sigma/src/rendering/programs/edge-double-clamped/index.ts
+++ b/packages/sigma/src/rendering/programs/edge-double-clamped/index.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { EdgeDisplayData, NodeDisplayData, RenderParams } from "../../../types";
 import { floatColor } from "../../../utils";

--- a/packages/sigma/src/rendering/programs/edge-line/index.ts
+++ b/packages/sigma/src/rendering/programs/edge-line/index.ts
@@ -6,7 +6,7 @@
  * won't render thickness correctly on some GPUs and has some quirks.
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { EdgeDisplayData, NodeDisplayData, RenderParams } from "../../../types";
 import { floatColor } from "../../../utils";

--- a/packages/sigma/src/rendering/programs/edge-rectangle/index.ts
+++ b/packages/sigma/src/rendering/programs/edge-rectangle/index.ts
@@ -15,7 +15,7 @@
  * the CPU & GPU (normals are computed on the CPU side).
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { EdgeDisplayData, NodeDisplayData, RenderParams } from "../../../types";
 import { floatColor } from "../../../utils";

--- a/packages/sigma/src/rendering/programs/edge-triangle/index.ts
+++ b/packages/sigma/src/rendering/programs/edge-triangle/index.ts
@@ -5,7 +5,7 @@
  * Program rendering directed edges as a single triangle.
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { EdgeDisplayData, NodeDisplayData, RenderParams } from "../../../types";
 import { floatColor } from "../../../utils";

--- a/packages/sigma/src/rendering/programs/node-circle/index.ts
+++ b/packages/sigma/src/rendering/programs/node-circle/index.ts
@@ -8,7 +8,7 @@
  * indicating which "corner" of the triangle to draw.
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { NodeDisplayData, RenderParams } from "../../../types";
 import { floatColor } from "../../../utils";

--- a/packages/sigma/src/rendering/programs/node-point/index.ts
+++ b/packages/sigma/src/rendering/programs/node-point/index.ts
@@ -7,7 +7,7 @@
  * every GPU.
  * @module
  */
-import { Attributes } from "graphology-types";
+import { Attributes } from "../../../graph";
 
 import { NodeDisplayData, RenderParams } from "../../../types";
 import { floatColor } from "../../../utils";

--- a/packages/sigma/src/settings.ts
+++ b/packages/sigma/src/settings.ts
@@ -5,8 +5,6 @@
  * The list of settings and some handy functions.
  * @module
  */
-import { Attributes } from "graphology-types";
-
 import {
   EdgeArrowProgram,
   EdgeLabelDrawingFunction,
@@ -20,6 +18,7 @@ import {
   drawDiscNodeLabel,
   drawStraightEdgeLabel,
 } from "./rendering";
+import { Attributes } from "./graph";
 import { AtLeastOne, EdgeDisplayData, NodeDisplayData } from "./types";
 import { assign } from "./utils";
 

--- a/packages/sigma/src/sigma.ts
+++ b/packages/sigma/src/sigma.ts
@@ -3,13 +3,12 @@
  * ========
  * @module
  */
-import Graph, { Attributes } from "graphology-types";
-
 import Camera from "./core/camera";
 import { cleanMouseCoords } from "./core/captors/captor";
 import MouseCaptor from "./core/captors/mouse";
 import TouchCaptor from "./core/captors/touch";
 import { LabelGrid, edgeLabelsToDisplayFromNodes } from "./core/labels";
+import { Attributes, SigmaGraph } from "./graph";
 import { AbstractEdgeProgram, AbstractNodeProgram, EdgeProgramType, NodeProgramType } from "./rendering";
 import { Settings, resolveSettings, validateSettings } from "./settings";
 import {
@@ -124,7 +123,7 @@ export default class Sigma<
   G extends Attributes = Attributes,
 > extends TypedEventEmitter<SigmaEvents> {
   private settings: Settings<N, E, G>;
-  private graph: Graph<N, E, G>;
+  private graph: SigmaGraph<N, E, G>;
   private mouseCaptor: MouseCaptor<N, E, G>;
   private touchCaptor: TouchCaptor<N, E, G>;
   private container: HTMLElement;
@@ -189,7 +188,7 @@ export default class Sigma<
 
   private camera: Camera;
 
-  constructor(graph: Graph<N, E, G>, container: HTMLElement, settings: Partial<Settings<N, E, G>> = {}) {
+  constructor(graph: SigmaGraph<N, E, G>, container: HTMLElement, settings: Partial<Settings<N, E, G>> = {}) {
     super();
 
     // Resolving settings
@@ -1787,7 +1786,7 @@ export default class Sigma<
    *
    * @return {Graph}
    */
-  getGraph(): Graph<N, E, G> {
+  getGraph(): SigmaGraph<N, E, G> {
     return this.graph;
   }
 
@@ -1796,7 +1795,7 @@ export default class Sigma<
    *
    * @return {Graph}
    */
-  setGraph(graph: Graph<N, E, G>): void {
+  setGraph(graph: SigmaGraph<N, E, G>): void {
     if (graph === this.graph) return;
 
     // Check hoveredNode and hoveredEdge

--- a/packages/sigma/src/types.ts
+++ b/packages/sigma/src/types.ts
@@ -190,3 +190,4 @@ export type SigmaEventType = keyof SigmaEvents;
 export type { CameraEvents } from "./core/camera";
 export type { MouseCaptorEvents } from "./core/captors/mouse";
 export type { TouchCaptorEvents } from "./core/captors/touch";
+export type { Attributes, SigmaGraph } from "./graph";

--- a/packages/sigma/src/utils/animate.ts
+++ b/packages/sigma/src/utils/animate.ts
@@ -1,5 +1,4 @@
-import Graph from "graphology-types";
-
+import { SigmaGraph } from "../graph";
 import { PlainObject } from "../types";
 import { easings } from "./easings";
 
@@ -21,7 +20,7 @@ export const ANIMATE_DEFAULTS = {
  * Function used to animate the nodes.
  */
 export function animateNodes(
-  graph: Graph,
+  graph: SigmaGraph,
   targets: PlainObject<PlainObject<number>>,
   opts: Partial<AnimateOptions>,
   callback?: () => void,

--- a/packages/sigma/src/utils/graph.ts
+++ b/packages/sigma/src/utils/graph.ts
@@ -1,12 +1,10 @@
-import Graph, { Attributes } from "graphology-types";
-import isGraph from "graphology-utils/is-graph";
-
+import { Attributes, SigmaGraph } from "../graph";
 import { Extent } from "../types";
 
 /**
  * Function returning the graph's node extent in x & y.
  */
-export function graphExtent(graph: Graph): { x: Extent; y: Extent } {
+export function graphExtent(graph: SigmaGraph): { x: Extent; y: Extent } {
   if (!graph.order) return { x: [0, 1], y: [0, 1] };
 
   let xMin = Infinity;
@@ -30,9 +28,23 @@ export function graphExtent(graph: Graph): { x: Extent; y: Extent } {
 /**
  * Check if the graph variable is a valid graph, and if sigma can render it.
  */
-export function validateGraph(graph: Graph): void {
-  // check if it's a valid graphology instance
-  if (!isGraph(graph)) throw new Error("Sigma: invalid graph instance.");
+export function validateGraph(graph: SigmaGraph): void {
+  const methods = [
+    "nodes",
+    "edges",
+    "forEachNode",
+    "forEachEdge",
+    "getNodeAttributes",
+    "getEdgeAttributes",
+    "hasNode",
+    "hasEdge",
+    "extremities",
+    "on",
+    "removeListener",
+  ];
+
+  if (!graph || methods.some((method) => typeof (graph as unknown as Record<string, unknown>)[method] !== "function"))
+    throw new Error("Sigma: invalid graph instance.");
 
   // check if nodes have x/y attributes
   graph.forEachNode((key: string, attributes: Attributes) => {


### PR DESCRIPTION
## Summary
- Add a browser-safe CSR-backed `IcebugSigmaGraph` adapter for read-only Sigma rendering.
- Remove the eager `@ladybugmem/icebug` native addon import from the Sigma browser entrypoint.
- Keep Arrow column tables for node and edge metadata while supporting CSR construction directly.

## Validation
- Not rerun in this checkout after the final patch because the local Homebrew `node` binary is currently linked against missing `libllhttp.9.3.dylib`.
- The same CSR implementation was built successfully through the Bugscope frontend before the local Node install broke.
