### PR TITLE
fix: use cached matrix in viewportToFramedGraph when no override is given

### DIFF
--- a/packages/sigma/src/sigma.ts
+++ b/packages/sigma/src/sigma.ts
@@ -2248,7 +2248,7 @@ export default class Sigma<
    * of computations.
    */
   viewportToFramedGraph(coordinates: Coordinates, override: CoordinateConversionOverride = {}): Coordinates {
-    const recomputeMatrix = !!override.cameraState || !!override.viewportDimensions || !override.graphDimensions;
+    const recomputeMatrix = !!override.cameraState || !!override.viewportDimensions || !!override.graphDimensions;
     const invMatrix = override.matrix
       ? override.matrix
       : recomputeMatrix


### PR DESCRIPTION
### Bug

`viewportToFramedGraph` computes `recomputeMatrix` with a single negation on the last term:

```ts
// viewportToFramedGraph (line ~2251)
const recomputeMatrix = !!override.cameraState || !!override.viewportDimensions || !override.graphDimensions;
```

while its sibling `framedGraphToViewport` uses a double negation:

```ts
// framedGraphToViewport (line ~2223)
const recomputeMatrix = !!override.cameraState || !!override.viewportDimensions || !!override.graphDimensions;
```

`recomputeMatrix` is meant to be `true` only when the caller passes an override that affects the matrix. Because of the stray single `!`, `viewportToFramedGraph` instead recomputes whenever `graphDimensions` is **not** provided — i.e. on the normal no-override calls made by the mouse (`mouse.ts` drag/pan, wheel zoom) and touch handlers.

### Impact

On those paths the method bypasses the cached `this.invMatrix` and rebuilds the inverse from the **live** `this.camera.getState()`, whereas `framedGraphToViewport` correctly uses `this.matrix` snapshotted at the last `render()`. During a camera animation the live state runs ahead of the rendered matrix, so the two conversions operate on different camera states within the same frame — causing the round-trip to desync (jumpy pan/zoom anchoring).

### Fix

Change `!override.graphDimensions` → `!!override.graphDimensions`, matching `framedGraphToViewport`. This is the same one-character fix already present on the `v4` branch (commit `940ad72a`); this backports it to `main`.