### PR TITLE
fix(core): ensure renderer refresh when only hideLabelsOnMove is enabled

### DIFF
--- a/packages/sigma/src/core/captors/mouse.ts
+++ b/packages/sigma/src/core/captors/mouse.ts
@@ -224,13 +224,15 @@ export default class MouseCaptor<
       const shouldRefresh = this.draggedEvents > 0;
       this.draggedEvents = 0;
 
-      // NOTE: this refresh is here to make sure `hideEdgesOnMove` can work
+      // NOTE: this refresh is here to make sure `hideEdgesOnMove` and `hideLabelsOnMove` can work
       // when someone releases camera pan drag after having stopped moving.
       // See commit: https://github.com/jacomyal/sigma.js/commit/cfd9197f70319109db6b675dd7c82be493ca95a2
       // See also issue: https://github.com/jacomyal/sigma.js/issues/1290
       // It could be possible to render instead of scheduling a refresh but for
       // now it seems good enough.
-      if (shouldRefresh && this.renderer.getSetting("hideEdgesOnMove")) this.renderer.refresh();
+      const shouldRestoreDeferredRendering =
+        this.renderer.getSetting("hideEdgesOnMove") || this.renderer.getSetting("hideLabelsOnMove");
+      if (shouldRefresh && shouldRestoreDeferredRendering) this.renderer.refresh();
     }, 0);
     this.emit("mouseup", getMouseCoords(e, this.container));
   }


### PR DESCRIPTION
Fix a logic omission in mouseup handler where the graph failed to refresh after dragging if only `hideLabelsOnMove` was set to true.

## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Before to create a PR, read our [contributing guide](https://github.com/jacomyal/sigma.js/blob/main/CONTRIBUTING.md)

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

When the renderer is configured with `hideLabelsOnMove: true` but `hideEdgesOnMove: false`, the graph fails to refresh upon releasing the mouse after a camera pan or drag action. 

As a result, the graph remains in its simplified "moving" state where labels stay hidden even after the movement has completely stopped. This happens because the `mouseup` (or drag end) handler previously only checked `this.renderer.getSetting("hideEdgesOnMove")` before triggering `this.renderer.refresh()`.

## What is the new behavior?

The conditional check in the delayed `mouseup` handler has been updated to include `this.renderer.getSetting("hideLabelsOnMove")`. 

Now, if **either** `hideEdgesOnMove` or `hideLabelsOnMove` is enabled, `this.renderer.refresh()` will be correctly invoked when the user stops moving the camera, ensuring that both edges and labels restore their proper visibility states smoothly.

## Other information

Bug:
<img width="845" height="590" alt="Bug" src="https://github.com/user-attachments/assets/f460e401-fc3a-4741-8ae5-701508f7a85d" />

Fixed:
<img width="845" height="589" alt="Fixed" src="https://github.com/user-attachments/assets/8decf43d-0300-4535-a104-86910093498b" />

