### PR TITLE
Fix node sizing in the v4 CDN quickstart

### DIFF
--- a/packages/website/src/content/docs/get-started/quickstart.mdx
+++ b/packages/website/src/content/docs/get-started/quickstart.mdx
@@ -54,7 +54,9 @@ With the CDN links, it's possible to write a single HTML document, with minimal 
       graph.addEdge("1", "2", { size: 5, color: "purple" });
 
       // Instantiate sigma.js and render the graph
-      const renderer = new Sigma(graph, document.getElementById("container"));
+      const renderer = new Sigma(graph, document.getElementById("container"), {
+        settings: { itemSizesReference: "screen" },
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## What is the current behavior?

The all-included CDN quickstart uses node sizes intended as screen pixels, while Sigma v4 defaults to interpreting item sizes in graph-position space. With positions ranging from 0 to 1, the red node fills the entire stage.

Fixes #1547

## What is the new behavior?

The example opts into screen-referenced item sizes, so the documented 10px and 20px nodes render as a normal two-node graph.

## Testing

- `npm exec prettier -- --check packages/website/src/content/docs/get-started/quickstart.mdx`
- `npm run check --workspace=@sigma/website`
- `npm run build --workspace=@sigma/website`
- Rendered the exact HTML block from `quickstart.mdx` with Sigma 4.0.0-alpha.7 and Graphology 0.26.0 in Chromium; red pixels occupy 0.24% of the 800x600 stage instead of the full stage.