### PR TITLE
[sigma] Stop hidden items from aliasing texture row 0

### DIFF
--- a/packages/sigma/src/hidden-items.test.ts
+++ b/packages/sigma/src/hidden-items.test.ts
@@ -1,0 +1,130 @@
+import Graph from "graphology";
+import { SerializedGraph } from "graphology-types";
+import Sigma from "sigma";
+import { Coordinates } from "sigma/types";
+import { createElement } from "sigma/utils";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { simulateMouseEvent, wait } from "./_test-helpers";
+
+const STAGE_WIDTH = 300;
+const STAGE_HEIGHT = 600;
+
+/**
+ * `n1` and `e1` are declared first, so they are the first items allocated in
+ * their data textures and end up at row 0 — the row a zeroed-out vertex buffer
+ * slot points at. `n3` / `e2` are the items the tests hide.
+ */
+const GRAPH: Pick<SerializedGraph, "nodes" | "edges"> = {
+  nodes: [
+    { key: "n1", attributes: { x: 0, y: 0, size: 10, color: "blue" } },
+    { key: "n2", attributes: { x: 50, y: 50, size: 10, color: "red" } },
+    { key: "n3", attributes: { x: 50, y: 0, size: 10, color: "green" } },
+  ],
+  edges: [
+    { key: "e1", source: "n1", target: "n2", attributes: { size: 10 } },
+    { key: "e2", source: "n1", target: "n3", attributes: { size: 10 } },
+  ],
+};
+
+let instances: Sigma[] = [];
+
+function mount({ hiddenNode, hiddenEdge }: { hiddenNode?: string; hiddenEdge?: string } = {}) {
+  const graph = new Graph();
+  graph.import(GRAPH);
+  const container = createElement("div", {
+    width: `${STAGE_WIDTH}px`,
+    height: `${STAGE_HEIGHT}px`,
+  }) as HTMLDivElement;
+  document.body.append(container);
+
+  // Reducers are constructor options, not settings:
+  const sigma = new Sigma(graph, container, {
+    settings: { enableEdgeEvents: true },
+    nodeReducer: hiddenNode ? (node, data) => (node === hiddenNode ? { ...data, visibility: "hidden" } : data) : undefined,
+    edgeReducer: hiddenEdge ? (edge, data) => (edge === hiddenEdge ? { ...data, visibility: "hidden" } : data) : undefined,
+  });
+  instances.push(sigma);
+
+  return { sigma, graph, container };
+}
+
+/** Viewport position of `n1`, which owns node-data-texture row 0. */
+function rowZeroNodePosition(sigma: Sigma, graph: Graph): Coordinates {
+  return sigma.graphToViewport(graph.getNodeAttributes("n1") as Coordinates);
+}
+
+/** Viewport position of the middle of `e1`, which owns edge-data-texture row 0. */
+function rowZeroEdgePosition(sigma: Sigma, graph: Graph): Coordinates {
+  const n1 = graph.getNodeAttributes("n1") as Coordinates;
+  const n2 = graph.getNodeAttributes("n2") as Coordinates;
+  return sigma.graphToViewport({ x: (n1.x + n2.x) / 2, y: (n1.y + n2.y) / 2 });
+}
+
+afterEach(() => {
+  instances.forEach((sigma) => {
+    sigma.kill();
+    sigma.getContainer().remove();
+  });
+  instances = [];
+});
+
+/**
+ * Regression tests: hiding *any* item used to break the item at texture row 0.
+ *
+ * A hidden item's vertex buffer slot is zeroed out, which leaves
+ * `a_nodeIndex` / `a_edgeIndex` at 0 and `a_id` at 0. Row 0 is a valid item, so
+ * the hidden instance was drawn using item 0's geometry and attributes, and —
+ * because the picking pass runs with blending disabled — its `a_id = 0`
+ * overwrote item 0's real picking ID. Item 0 therefore became impossible to
+ * hover or click even though it was perfectly visible.
+ */
+describe("Hidden items", () => {
+  test("a node at texture row 0 is hoverable when nothing is hidden", async () => {
+    const { sigma, graph } = mount();
+    await wait(100);
+
+    const entered: string[] = [];
+    sigma.addListener("enterNode", ({ node }) => entered.push(node));
+    await simulateMouseEvent(sigma.getMouseLayer(), "pointermove", rowZeroNodePosition(sigma, graph));
+    await wait(50);
+
+    expect(entered).toEqual(["n1"]);
+  });
+
+  test("a node at texture row 0 stays hoverable while another node is hidden", async () => {
+    const { sigma, graph } = mount({ hiddenNode: "n3" });
+    await wait(100);
+
+    const entered: string[] = [];
+    sigma.addListener("enterNode", ({ node }) => entered.push(node));
+    await simulateMouseEvent(sigma.getMouseLayer(), "pointermove", rowZeroNodePosition(sigma, graph));
+    await wait(50);
+
+    expect(entered).toEqual(["n1"]);
+  });
+
+  test("an edge at texture row 0 is hoverable when nothing is hidden", async () => {
+    const { sigma, graph } = mount();
+    await wait(100);
+
+    const entered: string[] = [];
+    sigma.addListener("enterEdge", ({ edge }) => entered.push(edge));
+    await simulateMouseEvent(sigma.getMouseLayer(), "pointermove", rowZeroEdgePosition(sigma, graph));
+    await wait(50);
+
+    expect(entered).toEqual(["e1"]);
+  });
+
+  test("an edge at texture row 0 stays hoverable while another edge is hidden", async () => {
+    const { sigma, graph } = mount({ hiddenEdge: "e2" });
+    await wait(100);
+
+    const entered: string[] = [];
+    sigma.addListener("enterEdge", ({ edge }) => entered.push(edge));
+    await simulateMouseEvent(sigma.getMouseLayer(), "pointermove", rowZeroEdgePosition(sigma, graph));
+    await wait(50);
+
+    expect(entered).toEqual(["e1"]);
+  });
+});

--- a/packages/sigma/src/rendering/data-texture.ts
+++ b/packages/sigma/src/rendering/data-texture.ts
@@ -19,6 +19,17 @@ const GROWTH_FACTOR = 1.5;
 const MAX_TEXTURE_WIDTH = 4096;
 
 /**
+ * Sentinel written to `a_nodeIndex` / `a_edgeIndex` for hidden items.
+ *
+ * Programs zero out a hidden item's whole vertex buffer slot, but 0 is a *valid*
+ * texture row, so a zeroed slot is indistinguishable from "item at row 0" — the
+ * shader would happily render the hidden instance using item 0's geometry and
+ * attributes. Flagging the row with a negative value lets the vertex shader
+ * detect the case and discard the primitive instead.
+ */
+export const HIDDEN_ITEM_INDEX = -1;
+
+/**
  * Base class for GPU data textures.
  *
  * The texture is a 2D RGBA32F texture where each item uses TEXELS_PER_ITEM texels.

--- a/packages/sigma/src/rendering/edges/factory.ts
+++ b/packages/sigma/src/rendering/edges/factory.ts
@@ -15,6 +15,7 @@ import { colorToArray, floatColor, indexToColor, rgbaToFloat } from "../../utils
 import {
   AttrDescriptor,
   AttributeLayout,
+  HIDDEN_ITEM_INDEX,
   ItemAttributeTexture,
   buildAttrDescriptors,
   computeAttributeLayout,
@@ -301,11 +302,15 @@ export function createEdgeProgram<
       edgeTextureIndex: number,
     ): void {
       let i = offset * this.STRIDE;
-      // Hidden source/target/edge zero out the slot so the GPU draws nothing.
+      // Hidden source/target/edge zero out the slot so the GPU draws nothing,
+      // then a_edgeIndex is flagged as HIDDEN_ITEM_INDEX: zero is a *valid*
+      // texture row, so leaving it at 0 would make the shader render this
+      // instance as a copy of edge 0 (and overwrite its picking ID).
       if (data.visibility === "hidden" || sourceData.visibility === "hidden" || targetData.visibility === "hidden") {
         for (let l = i + this.STRIDE; i < l; i++) {
           this.floats[i] = 0;
         }
+        this.floats[offset * this.STRIDE] = HIDDEN_ITEM_INDEX;
         return;
       }
       this.processVisibleItem(indexToColor(edgeIndex), i, sourceData, targetData, data, edgeTextureIndex);

--- a/packages/sigma/src/rendering/edges/generator.ts
+++ b/packages/sigma/src/rendering/edges/generator.ts
@@ -722,6 +722,18 @@ void main() {
   // Texel 0: sourceNodeIndex, targetNodeIndex, thickness, reserved
   // Texel 1: headLengthRatio, tailLengthRatio, pathId, (headId << 4) | tailId
   int edgeIdx = int(a_edgeIndex);
+
+  // Hidden edges are flagged with a negative row by EdgeProgram.process(). Push
+  // the whole primitive outside the clip volume: every vertex lands at the same
+  // out-of-range position, so it is fully clipped and rasterizes nothing —
+  // neither to the frame buffer nor to the picking buffer.
+  if (edgeIdx < 0) {
+    gl_Position = vec4(2.0, 0.0, 0.0, 1.0);
+    v_color = vec4(0.0);
+    v_id = vec4(0.0);
+    return;
+  }
+
   int texel0Idx = edgeIdx * 2;
   int texel1Idx = edgeIdx * 2 + 1;
   ivec2 edgeTexCoord0 = ivec2(texel0Idx % u_edgeDataTextureWidth, texel0Idx / u_edgeDataTextureWidth);

--- a/packages/sigma/src/rendering/nodes/factory.ts
+++ b/packages/sigma/src/rendering/nodes/factory.ts
@@ -15,6 +15,7 @@ import { LabelDisplayData, NodeDisplayData, RenderParams } from "../../types";
 import { indexToColor } from "../../utils";
 import {
   AttrDescriptor,
+  HIDDEN_ITEM_INDEX,
   ItemAttributeTexture,
   buildAttrDescriptors,
   computeAttributeLayout,
@@ -297,11 +298,15 @@ export function createNodeProgram<
 
     process(nodeIndex: number, offset: number, data: NodeDisplayData, textureIndex: number, nodeKey: string): void {
       let i = offset * this.STRIDE;
-      // Hidden nodes get zeroed out so the GPU draws nothing for them.
+      // Hidden nodes get zeroed out so the GPU draws nothing for them, then
+      // a_nodeIndex is flagged as HIDDEN_ITEM_INDEX: zero is a *valid* texture
+      // row, so leaving it at 0 would make the shader render this instance as a
+      // copy of item 0 (and overwrite its picking ID with a_id = 0).
       if (data.visibility === "hidden") {
         for (let l = i + this.STRIDE; i < l; i++) {
           this.floats[i] = 0;
         }
+        this.floats[offset * this.STRIDE] = HIDDEN_ITEM_INDEX;
         return;
       }
       this.processVisibleItem(indexToColor(nodeIndex), i, data, textureIndex, nodeKey);

--- a/packages/sigma/src/rendering/nodes/generator.ts
+++ b/packages/sigma/src/rendering/nodes/generator.ts
@@ -148,6 +148,17 @@ ${GLSL_READ_NODE_FLAGS}
 void main() {
   // Fetch node geometry: vec4(x, y, size, shapeId).
   int nodeIdx = int(a_nodeIndex);
+
+  // Hidden nodes are flagged with a negative row by NodeProgram.process(). Push
+  // the whole quad outside the clip volume: every vertex lands at the same
+  // out-of-range position, so the primitive is fully clipped and rasterizes
+  // nothing — neither to the frame buffer nor to the picking buffer.
+  if (nodeIdx < 0) {
+    gl_Position = vec4(2.0, 0.0, 0.0, 1.0);
+    v_id = vec4(0.0);
+    return;
+  }
+
   vec4 nodeData = readNodeData(u_nodeDataTexture, u_nodeDataTextureWidth, nodeIdx);
   vec2 a_position = nodeData.xy;
   float a_size = nodeData.z;


### PR DESCRIPTION
Fixes #1549.

## Problem

`NodeProgram.process()` / `EdgeProgram.process()` express "hidden" by zeroing the item's whole vertex buffer slot. That worked in v3, where the buffer held coordinates and sizes and all-zeros collapsed the quad. In v4 the geometry lives in textures and the buffer only holds a texture row plus a picking ID — and row `0` is a **valid** row, so a zeroed slot is indistinguishable from *"the item at row 0"*.

Two observable consequences:

- The hidden instance is drawn with row 0's geometry **and** layer attributes — a pixel-perfect duplicate stacked on item 0.
- The picking pass runs with blending disabled, so the hidden instance's `a_id = 0` overwrites item 0's real picking ID. **Item 0 stops being hoverable/clickable while any other item is hidden**, despite rendering fine.

## Change

Write a negative sentinel (`HIDDEN_ITEM_INDEX`) into `a_nodeIndex` / `a_edgeIndex` instead of leaving it at `0`, and have the node and edge vertex shaders discard those instances by pushing every vertex to the same out-of-range clip position. The primitive is then fully clipped and never rasterizes — to the frame buffer or the picking buffer.

This is the same "don't draw this one" idiom the node label program already uses (`if (labelW <= 0.0) { gl_Position = vec4(2.0, 0.0, 0.0, 1.0); ... return; }`), including zeroing the picking varying on the way out.

Five small edits:

| File | Change |
| --- | --- |
| `rendering/data-texture.ts` | export `HIDDEN_ITEM_INDEX = -1` with the rationale |
| `rendering/nodes/factory.ts` | flag the row after zeroing the slot |
| `rendering/nodes/generator.ts` | discard negative rows in the vertex shader |
| `rendering/edges/factory.ts` | same as nodes |
| `rendering/edges/generator.ts` | same as nodes |

## Why not reserve row 0 instead

Starting `DataTexture.nextIndex` at 1 is a smaller diff, but I don't think it's the right call:

- It changes the allocator's contract to work around a bug that isn't in the allocator — `process()` writing a valid index to mean "none" is the actual defect. It also flips the existing `allocates sequential indices for new keys` expectation in `data-texture.test.ts`.
- It makes hidden items depend on `size == 0` collapsing the quad, which is implicit rather than stated, and breaks down in the picking pass: `paddedSize = size + u_pickingPadding * u_correctionRatio` is non-zero as soon as `nodePickingPadding` is set, and `v_uv = a_quadCorner * (paddedSize / size)` divides by zero.

Happy to switch if you'd rather go that route.

## Tests

New `packages/sigma/src/hidden-items.test.ts`: hovers the item that owns texture row 0, with and without another item hidden, for both nodes and edges.

The two "stays hoverable" cases **fail on `v4` without this patch** and pass with it; the two control cases pass either way — so the test genuinely covers the regression rather than passing vacuously.

```
# before (fix reverted, test kept)
× a node at texture row 0 stays hoverable while another node is hidden
× an edge at texture row 0 stays hoverable while another edge is hidden
  Tests  2 failed | 2 passed (4)

# after
  Tests  4 passed (4)
```

Full suite on this branch:

- `npm run test:unit` → 41 files, 450 passed
- `npm run test:type` → 7 files, 48 passed, no type errors
- `npx eslint` on the touched files → clean

I have not run `test:e2e` (needs the browser-tests workspace fixtures); happy to if useful.

## Not included

#1549 also describes a second, independent defect: edge path attribute rows drift because `ItemAttributeTexture.updateAllAttributes()` allocates rows in first-seen order while the GLSL addresses them by `edgeIdx`, so a hidden edge shifts every later visible edge's dash/gap/curvature row. I left it out because the fix looks like a design call between three options — I sketched them in the issue and can follow up with a PR once you've picked one.
