### PR TITLE
[sigma] Fixes atlas page cropped to 1px on overflow

### DIFF
--- a/packages/sigma/src/core/sdf-atlas.test.ts
+++ b/packages/sigma/src/core/sdf-atlas.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for SDFAtlasManager's texture paging.
+ *
+ * Glyphs are packed into fixed-size pages, and every finalized page is captured
+ * with `getImageData`. The capture width has to reflect what the page actually
+ * holds: cropping a page that already carries completed rows discards its
+ * glyphs, and since the label programs only ever upload page 0, that shows up
+ * as labels rendering with no visible text at all.
+ */
+import { describe, expect, test } from "vitest";
+
+import { SDFAtlasManager } from "./sdf-atlas";
+
+const FONT = { family: "sans-serif", weight: "normal", style: "normal" };
+
+// Enough distinct characters to fill several rows of a deliberately tiny page.
+const GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+function createManager(maxTextureSize: number) {
+  return new SDFAtlasManager({ fontSize: 32, maxTextureSize, debounceTimeout: null });
+}
+
+describe("SDFAtlasManager", () => {
+  test("keeps a page that holds completed rows at full width when overflowing", () => {
+    const maxTextureSize = 128;
+    const manager = createManager(maxTextureSize);
+    const fontKey = manager.registerFont(FONT);
+
+    manager.ensureGlyphs(GLYPHS, fontKey);
+    manager.flush();
+
+    const textures = manager.getTextures();
+
+    // The point of the tiny page size: this must actually have overflowed.
+    expect(textures.length).toBeGreaterThan(1);
+    expect(textures[0].width).toBe(maxTextureSize);
+    for (const [index, page] of textures.entries()) {
+      expect(page.width, `page ${index} was cropped`).toBeGreaterThan(1);
+    }
+
+    manager.destroy();
+  });
+
+  test("packs a small glyph set into a single page", () => {
+    const manager = createManager(2048);
+    const fontKey = manager.registerFont(FONT);
+
+    manager.ensureGlyphs("abc", fontKey);
+    manager.flush();
+
+    const textures = manager.getTextures();
+
+    expect(textures).toHaveLength(1);
+    expect(textures[0].width).toBeGreaterThan(1);
+    expect(manager.getGlyphCount()).toBe(3);
+
+    manager.destroy();
+  });
+});

--- a/packages/sigma/src/core/sdf-atlas.ts
+++ b/packages/sigma/src/core/sdf-atlas.ts
@@ -583,10 +583,11 @@ export class SDFAtlasManager extends EventEmitter {
   private finalizeCurrentTexture(): void {
     const { maxTextureSize } = this.options;
 
-    const effectiveWidth = Math.min(
-      maxTextureSize,
-      Math.max(this.cursor.x, this.cursor.rowHeight > 0 ? maxTextureSize : 1),
-    );
+    // A page that already holds a completed row spans the full width, even when the
+    // cursor sits at x = 0: overflow finalizes right after the row wrap reset x and
+    // rowHeight, and reading cursor.x alone would then crop the page down to 1px.
+    const hasCompletedRow = this.cursor.y > 0 || this.cursor.rowHeight > 0;
+    const effectiveWidth = Math.min(maxTextureSize, Math.max(this.cursor.x, hasCompletedRow ? maxTextureSize : 1));
     const effectiveHeight = Math.min(maxTextureSize, this.cursor.y + this.cursor.rowHeight + GLYPH_MARGIN);
 
     const textureData = this.ctx.getImageData(0, 0, effectiveWidth, effectiveHeight);


### PR DESCRIPTION
Fixes the finalize-width half of #1552.

## The bug

`SDFAtlasManager.finalizeCurrentTexture()` derives the capture width from `cursor.x` when no row is in progress:

```ts
Math.max(this.cursor.x, this.cursor.rowHeight > 0 ? maxTextureSize : 1)
```

On overflow the packer wraps the row *before* checking whether the glyph still fits vertically, so by the time `finalizeCurrentTexture()` runs, both `cursor.x` and `cursor.rowHeight` are back to `0`. The page about to be replaced is then captured 1px wide and loses every glyph it holds — the `1×1947` pages reported in #1552.

Because the label programs upload `textures[0]` only, when page 0 is the cropped one every label draws with no visible text at all, with nothing logged.

## The fix

A page whose cursor has already moved past the first row spans the full width, so test `cursor.y` as well:

```ts
const hasCompletedRow = this.cursor.y > 0 || this.cursor.rowHeight > 0;
const effectiveWidth = Math.min(maxTextureSize, Math.max(this.cursor.x, hasCompletedRow ? maxTextureSize : 1));
```

This only changes the `y > 0 && rowHeight === 0` case, which is exactly the page-turn moment. The empty-atlas case (`y === 0 && rowHeight === 0`, the 1×1 placeholder) and the partial-first-row case are untouched.

## Test

`packages/sigma/src/core/sdf-atlas.test.ts` packs a 62-character set into a deliberately tiny 128px page to force a page turn, then asserts no finalized page was cropped. Reverting the source change makes it fail with `expected 1 to be 128`, reproducing the reported corruption. `vitest run --project sigma` passes (37 files, 412 tests).

## Not covered

The related multi-page upload noted in #1552 is untouched: packing still allocates `textures[1..n]`, and `updateAtlasTexture()` still uploads `textures[0]` only, so glyphs past the first page remain undrawn. `GlyphMetrics.atlasIndex` is already recorded but never read by any consumer, so the extension point exists — happy to follow up if you have a preferred design (texture array vs. per-character page index).
